### PR TITLE
Add missing API params to triggerBroadcast - Fixes #18

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ Trigger an email broadcast using the email campaign's id. You can also optionall
 cio.triggerBroadcast(1, { name: 'foo'}, { segment: { id: 7 }});
 ```
 
+You can also use emails or ids to select recipients, and pass optional API parameters such as `email_ignore_missing`. 
+
+```
+cio.triggerBroadcast(1, { name: 'foo'},  { emails: ['example@emails.com'], email_ignore_missing: true }
+);
+```
+
 #### Options
 
 * **id**: String (required)

--- a/lib/index.js
+++ b/lib/index.js
@@ -43,10 +43,17 @@ module.exports = class CustomerIO {
   }
 
   triggerBroadcast(id, data, recipients) {
-    return this.request.post(`${apiRoot}/campaigns/${id}/triggers`, {
-      data,
-      recipients
-    })
+    let payload = {};
+    if (recipients.emails || recipients.ids) {
+      // Add 'emails' or 'ids' as a root property of the payload object
+      payload = Object.assign({ data }, recipients);
+    } else {
+      payload = {
+        data,
+        recipients,
+      };
+    }
+    return this.request.post(`${apiRoot}/campaigns/${id}/triggers`, payload)
   }
 
   addToSegment(segmentId, customerIds = []) {

--- a/test/index.js
+++ b/test/index.js
@@ -84,6 +84,37 @@ test('#triggerBroadcast works', t => {
   )
 })
 
+test('#triggerBroadcast works with emails', t => {
+  sinon.stub(t.context.client.request, 'post')
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { emails: ['test@email.com'], email_ignore_missing: true, email_add_duplicates: true })
+  t.truthy(
+    t.context.client.request.post.calledWith(
+      `${apiRoot}/campaigns/1/triggers`,
+      {
+        data: { type: 'data' },
+        emails: ['test@email.com'],
+        email_ignore_missing: true,
+        email_add_duplicates: true,
+      }
+    )
+  )
+})
+
+test('#triggerBroadcast works with ids', t => {
+  sinon.stub(t.context.client.request, 'post')
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true })
+  t.truthy(
+    t.context.client.request.post.calledWith(
+      `${apiRoot}/campaigns/1/triggers`,
+      {
+        data: { type: 'data' },
+        ids: [1],
+        id_ignore_missing: true,
+      }
+    )
+  )
+})
+
 test('#addDevice works', t => {
   sinon.stub(t.context.client.request, 'put')
   t.context.client.addDevice(1, 123, 'ios', { primary: true });


### PR DESCRIPTION
This PR adds support for missing triggered broadcast API parameters to the `triggerBroadcast` method. 

It allows users to use `emails` or `ids` to indicate recipients. It is also possible to pass other optional params such as `email_ignore_missing `. 
Ex: 
```js
customerIO.triggerBroadcast(
  11,
  data,
  { emails: ['example@emails.com'], email_ignore_missing: true }
);
```
Changes are backwards-compatible so users can still call the method the same way as before, and indicate attributes and/or segment conditions. 

I've also updated tests and Readme. Let me know if you have any comments. 
Hope this helps