### PR TITLE
Add support for missing API params to triggerBroadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,12 +135,14 @@ Trigger an email broadcast using the email campaign's id. You can also optionall
 cio.triggerBroadcast(1, { name: 'foo'}, { segment: { id: 7 }});
 ```
 
-You can also use emails or ids to select recipients, and pass optional API parameters such as `email_ignore_missing`. 
+You can also use emails or ids to select recipients, and pass optional API parameters such as `email_ignore_missing`.
 
 ```
 cio.triggerBroadcast(1, { name: 'foo'},  { emails: ['example@emails.com'], email_ignore_missing: true }
 );
 ```
+
+[You can learn more about the recipient fields available here](https://customer.io/docs/api/#apicorecampaignscampaigns_trigger).
 
 #### Options
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,8 +44,8 @@ module.exports = class CustomerIO {
 
   triggerBroadcast(id, data, recipients) {
     let payload = {};
+
     if (recipients.emails || recipients.ids) {
-      // Add 'emails' or 'ids' as a root property of the payload object
       payload = Object.assign({ data }, recipients);
     } else {
       payload = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,18 @@ const Request = require('./request')
 const trackRoot = 'https://track.customer.io/api/v1'
 const apiRoot = 'https://api.customer.io/v1/api'
 
+const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
+  ids: ['ids', 'id_ignore_missing'],
+  emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
+  per_user_data: ['per_user_data'],
+  data_file_url: ['data_file_url']
+};
+
+const filterRecipientsDataForField = (recipients, field) => {
+  return BROADCASTS_ALLOWED_RECIPIENT_FIELDS[field]
+    .reduce((obj, field) => Object.assign(obj, { [field]: recipients[field] }), {});
+};
+
 module.exports = class CustomerIO {
   constructor(siteid, apikey) {
     this.siteid = siteid
@@ -44,15 +56,20 @@ module.exports = class CustomerIO {
 
   triggerBroadcast(id, data, recipients) {
     let payload = {};
+    let customRecipientField =
+      Object
+      .keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS)
+      .find(field => recipients[field]);
 
-    if (recipients.emails || recipients.ids) {
-      payload = Object.assign({ data }, recipients);
+    if (customRecipientField) {
+      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField));
     } else {
       payload = {
         data,
-        recipients,
+        recipients
       };
     }
+
     return this.request.post(`${apiRoot}/campaigns/${id}/triggers`, payload)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ const filterRecipientsDataForField = (recipients, field) => {
     .reduce((obj, field) => {
       obj[field] = recipients[field]
       return obj
-    })
+    }, {})
 }
 
 module.exports = class CustomerIO {

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,12 +7,15 @@ const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
   per_user_data: ['per_user_data'],
   data_file_url: ['data_file_url']
-};
+}
 
 const filterRecipientsDataForField = (recipients, field) => {
   return BROADCASTS_ALLOWED_RECIPIENT_FIELDS[field]
-    .reduce((obj, field) => Object.assign(obj, { [field]: recipients[field] }), {});
-};
+    .reduce((obj, field) => {
+      obj[field] = recipients[field]
+      return obj
+    })
+}
 
 module.exports = class CustomerIO {
   constructor(siteid, apikey) {
@@ -51,18 +54,18 @@ module.exports = class CustomerIO {
   }
 
   deleteDevice(id, token) {
-    return this.request.destroy(`${trackRoot}/customers/${id}/devices/${token}`);
+    return this.request.destroy(`${trackRoot}/customers/${id}/devices/${token}`)
   }
 
   triggerBroadcast(id, data, recipients) {
-    let payload = {};
+    let payload = {}
     let customRecipientField =
       Object
       .keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS)
-      .find(field => recipients[field]);
+      .find(field => recipients[field])
 
     if (customRecipientField) {
-      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField));
+      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField))
     } else {
       payload = {
         data,

--- a/test/index.js
+++ b/test/index.js
@@ -115,6 +115,21 @@ test('#triggerBroadcast works with ids', t => {
   )
 })
 
+test('#triggerBroadcast discards extraneous fields', t => {
+  sinon.stub(t.context.client.request, 'post')
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true, emails: ['test@email.com'], exampleField: true })
+  t.truthy(
+    t.context.client.request.post.calledWith(
+      `${apiRoot}/campaigns/1/triggers`,
+      {
+        data: { type: 'data' },
+        ids: [1],
+        id_ignore_missing: true,
+      }
+    )
+  )
+})
+
 test('#addDevice works', t => {
   sinon.stub(t.context.client.request, 'put')
   t.context.client.addDevice(1, 123, 'ios', { primary: true });


### PR DESCRIPTION
Follow up to #19. This PR adds stricter filtering for the recipients object, adds a test, and updates the README with a link to our documentation.