### PR TITLE
Support additional parameters when using ‘per_user_data’ in triggered broadcasts

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@ const apiRoot = 'https://api.customer.io/v1/api'
 
 const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   ids: ['ids', 'id_ignore_missing'],
-  emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
+  emails: ['emails', 'email_ignore_missing', 'email_add_duplicates', 'id_ignore_missing'],
   per_user_data: ['per_user_data', 'email_ignore_missing', 'email_add_duplicates'],
   data_file_url: ['data_file_url']
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ const apiRoot = 'https://api.customer.io/v1/api'
 const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   ids: ['ids', 'id_ignore_missing'],
   emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
-  per_user_data: ['per_user_data'],
+  per_user_data: ['per_user_data', 'email_ignore_missing', 'email_add_duplicates'],
   data_file_url: ['data_file_url']
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,8 @@ const apiRoot = 'https://api.customer.io/v1/api'
 
 const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   ids: ['ids', 'id_ignore_missing'],
-  emails: ['emails', 'email_ignore_missing', 'email_add_duplicates', 'id_ignore_missing'],
-  per_user_data: ['per_user_data', 'email_ignore_missing', 'email_add_duplicates'],
+  emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
+  per_user_data: ['per_user_data', 'email_ignore_missing', 'email_add_duplicates', 'id_ignore_missing'],
   data_file_url: ['data_file_url']
 }
 


### PR DESCRIPTION
Customerio’s REST API supports `email_ignore_missing`, `email_add_duplicates` and `id_ignore_missing` when triggering a broadcast with `per_user_data`, so should the client lib.  