### PR TITLE
Allow request options to be overridden

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,20 @@ In order to start using the library, you first need to create an instance of the
 
 ```
 let CIO = require('customerio-node');
-const cio = new CIO(siteId, apiKey);
+const cio = new CIO(siteId, apiKey, [defaults]);
 ```
 
 Both the `siteId` and `apiKey` are **required** in order to create a Basic Authorization header, allowing us to associate the data with your account.
+
+Optionally you may pass `defaults` as an object that will be passed to the underlying request instance. A list of the possible options are listed [here](https://github.com/request/request#requestoptions-callback).
+
+This is useful to override the default 10s timeout. Example:
+
+```
+const cio = new CIO(123, 'abc', {
+  timeout: 5000
+});
+```
 
 ---
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,10 +18,11 @@ const filterRecipientsDataForField = (recipients, field) => {
 }
 
 module.exports = class CustomerIO {
-  constructor(siteid, apikey) {
+  constructor(siteid, apikey, defaults) {
     this.siteid = siteid
     this.apikey = apikey
-    this.request = new Request(this.siteid, this.apikey)
+    this.defaults = defaults
+    this.request = new Request(this.siteid, this.apikey, this.defaults)
   }
 
   identify(id, data = {}) {

--- a/lib/request.js
+++ b/lib/request.js
@@ -2,14 +2,17 @@ const request = require('request')
 const TIMEOUT = 10000
 
 class Request {
-  constructor(siteid, apikey) {
+  constructor(siteid, apikey, defaults) {
     this.siteid = siteid
     this.apikey = apikey
+    this.defaults = Object.assign({
+      timeout: TIMEOUT
+    }, defaults)
     this.auth = `Basic ${Buffer.from(
       `${this.siteid}:${this.apikey}`,
       'utf8'
     ).toString('base64')}`
-    this._request = request
+    this._request = request.defaults(this.defaults)
   }
 
   options(uri, method, data) {
@@ -18,7 +21,7 @@ class Request {
       'Content-Type': 'application/json'
     }
     const body = data ? JSON.stringify(data) : null
-    const options = { method, uri, headers, body, timeout: TIMEOUT }
+    const options = { method, uri, headers, body }
 
     if (!body) delete options.body
 

--- a/test/request.js
+++ b/test/request.js
@@ -13,19 +13,24 @@ const baseOptions = {
   headers: {
     Authorization: auth,
     'Content-Type': 'application/json'
-  },
-  timeout: 10000
+  }
 }
 
 test.beforeEach(t => {
-  t.context.req = new Request(123, 'abc')
+  t.context.req = new Request(123, 'abc', { timeout: 5000 })
 })
 
 // tests begin here
 test('constructor sets all properties correctly', t => {
   t.is(t.context.req.siteid, 123)
   t.is(t.context.req.apikey, 'abc')
+  t.deepEqual(t.context.req.defaults, { timeout: 5000 })
   t.is(t.context.req.auth, auth)
+})
+
+test('constructor sets default timeout correctly', t => {
+  const req = new Request()
+  t.deepEqual(req.defaults, { timeout: 10000 })
 })
 
 test('#options returns a correctly formatted object', t => {
@@ -85,6 +90,22 @@ test('#handler makes a request and rejects with `null` as body', t => {
   return t.context.req
     .handler(customOptions)
     .catch(err => t.is(err.message, 'Unknown error'))
+})
+
+test('#handler makes a request and rejects with timeout error', t => {
+  const customOptions = Object.assign({}, baseOptions, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+    timeout: 1
+  })
+
+  const message = 'test error message'
+  const body = { meta: { error: message } }
+
+  return t.context.req
+    .handler(customOptions)
+    .then(t.fail)
+    .catch(err => t.is(err.message, 'ETIMEDOUT'))
 })
 
 test('#put calls the handler, makes PUT request with the correct args', t => {


### PR DESCRIPTION
Allows request options to be overridden. In particular, it allows customizing the default 10s timeout.