### PR TITLE
Fix inconsistent documentation for suppress method

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,16 @@ cio.removeFromSegment(1, ["1", "2", "3"])
 * **segment_id**: String (required)
 * **customer_ids**: Array (required)
 
-### cio.supress(id)
+### cio.suppress(id)
 Suppress a customer.
 
 ```
-cio.supress(1, ["1", "2", "3"])
+cio.suppress(1)
 ```
 
 #### Options
 
-* **segment_id**: String (required)
+* **customer_id**: String (required)
 
 ### Using Promises
 


### PR DESCRIPTION
This PR fixes the following inconsistencies regarding the documentation of `cio.suppress` within [README.md](https://github.com/customerio/customerio-node/blob/0278b672ad3558b0e4fbe2120e205e7b9bba887d/CHANGELOG.md):

* In two instances, `suppress` is misspelled `supress`.
* In the usage example, an unexpected 2nd argument is passed.
* The `id` option refers to a customer identifier but is described as `segment_id`.