### PR TITLE
Add options for different recipient fields

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,14 +5,16 @@ const apiRoot = 'https://api.customer.io/v1/api'
 const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   ids: ['ids', 'id_ignore_missing'],
   emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
-  per_user_data: ['per_user_data'],
-  data_file_url: ['data_file_url']
+  per_user_data: ['per_user_data', 'id_ignore_missing', 'email_ignore_missing', 'email_add_duplicates'],
+  data_file_url: ['data_file_url', 'id_ignore_missing', 'email_ignore_missing', 'email_add_duplicates']
 }
 
 const filterRecipientsDataForField = (recipients, field) => {
   return BROADCASTS_ALLOWED_RECIPIENT_FIELDS[field]
     .reduce((obj, field) => {
-      obj[field] = recipients[field]
+      if (!!recipients[field]) {
+        obj[field] = recipients[field]
+      }
       return obj
     }, {})
 }

--- a/test/index.js
+++ b/test/index.js
@@ -123,6 +123,38 @@ test('#triggerBroadcast works with ids', t => {
   )
 })
 
+test('#triggerBroadcast works with per_user_data', t => {
+  sinon.stub(t.context.client.request, 'post')
+  const per_user_data = [ { id: 1, data: { very: 'important' }} ]
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { per_user_data, id_ignore_missing: true })
+  t.truthy(
+    t.context.client.request.post.calledWith(
+      `${apiRoot}/campaigns/1/triggers`,
+      {
+        data: { type: 'data' },
+        per_user_data,
+        id_ignore_missing: true,
+      }
+    )
+  )
+})
+
+test('#triggerBroadcast works with data_file_url', t => {
+  sinon.stub(t.context.client.request, 'post')
+  const data_file_url = 'https://my.s3.bucket.com'
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { data_file_url, id_ignore_missing: true })
+  t.truthy(
+    t.context.client.request.post.calledWith(
+      `${apiRoot}/campaigns/1/triggers`,
+      {
+        data: { type: 'data' },
+        data_file_url,
+        id_ignore_missing: true,
+      }
+    )
+  )
+})
+
 test('#triggerBroadcast discards extraneous fields', t => {
   sinon.stub(t.context.client.request, 'post')
   t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true, emails: ['test@email.com'], exampleField: true })


### PR DESCRIPTION
Closes: https://github.com/customerio/customerio-node/issues/31

## What
Per the [customer.io API docs](https://customer.io/docs/api/#apicorecampaignscampaigns_trigger) , we should be able to pass through additional options when triggering a broadcast with `data_file_url` or `per_user_data`. Using an HTTP client locally, I am able to successfully include additional options when using `data_file_url` and `per_user_data`. 

## Why 
Right now the code is limiting options such as `id_ignore_missing`, `email_ignore_missing`, and `email_add_duplicates` to the `ids` and `email` recipient type fields. These options shouldn't be limited to just those recipient field types. 