### PR TITLE
Run prettier and update the node versions that we test against

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,9 +44,9 @@ jobs:
       - checkout
       - runtests
   
-  node-carbon: # EOL 2019-12-31
+  node-erbium: # EOL 2022-04-30
     docker:
-      - image: circleci/node:carbon
+      - image: circleci/node:erbium
 
     working_directory: ~/customerio-node
 
@@ -54,9 +54,9 @@ jobs:
       - checkout
       - runtests
 
-  node-boron: # EOL 2019-04-01
+  node-fermium: # EOL 2023-04-30
     docker:
-      - image: circleci/node:boron
+      - image: circleci/node:fermium
 
     working_directory: ~/customerio-node
 
@@ -70,5 +70,5 @@ workflows:
     jobs:
       - node-current
       - node-dubnium
-      - node-carbon
-      - node-boron
+      - node-erbium
+      - node-fermium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,9 @@ jobs:
       - checkout
       - runtests
 
-  node-dubnium: # EOL 2021-04-01
+  node-10:
     docker:
-      - image: circleci/node:dubnium
+      - image: circleci/node:10
 
     working_directory: ~/customerio-node
 
@@ -44,9 +44,9 @@ jobs:
       - checkout
       - runtests
   
-  node-erbium: # EOL 2022-04-30
+  node-12:
     docker:
-      - image: circleci/node:erbium
+      - image: circleci/node:12
 
     working_directory: ~/customerio-node
 
@@ -54,9 +54,9 @@ jobs:
       - checkout
       - runtests
 
-  node-fermium: # EOL 2023-04-30
+  node-14:
     docker:
-      - image: circleci/node:fermium
+      - image: circleci/node:14
 
     working_directory: ~/customerio-node
 
@@ -69,6 +69,6 @@ workflows:
   test:
     jobs:
       - node-current
-      - node-dubnium
-      - node-erbium
-      - node-fermium
+      - node-10
+      - node-12
+      - node-14

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,12 @@
+module.exports = {
+  printWidth: 120,
+  trailingComma: "all",
+  overrides: [
+    {
+      files: ["*.js", ".*.js"],
+      options: {
+        singleQuote: true,
+      },
+    },
+  ],
+};

--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -3,6 +3,6 @@ const config = {
   apiKey: 'changeme',
   customerId: '1',
   campaignId: '1',
-}
+};
 
-export default config
+export default config;

--- a/examples/destroy.js
+++ b/examples/destroy.js
@@ -1,4 +1,4 @@
-let CIO = require('../lib/index'); 
+let CIO = require('../lib/index');
 // In actual use require the node module: let CIO = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;

--- a/examples/identify.js
+++ b/examples/identify.js
@@ -9,5 +9,5 @@ cio.identify(customerId, {
   email: 'customer@example.com',
   created_at: 1361205308,
   first_name: 'Bob',
-  plan: 'basic'
+  plan: 'basic',
 });

--- a/examples/promises.js
+++ b/examples/promises.js
@@ -5,17 +5,19 @@ const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
 const cio = new CIO(siteId, apiKey);
 
-cio.identify(customerId, {
-  email: 'customer@example.com',
-  created_at: 1361205308,
-  first_name: 'Bob',
-  plan: 'basic'
-}).then(() => {
-  return cio.track(customerId, {
-    name: 'purchase',
-    data: {
-      price: '23.45',
-      product: 'socks'
-    }
+cio
+  .identify(customerId, {
+    email: 'customer@example.com',
+    created_at: 1361205308,
+    first_name: 'Bob',
+    plan: 'basic',
+  })
+  .then(() => {
+    return cio.track(customerId, {
+      name: 'purchase',
+      data: {
+        price: '23.45',
+        product: 'socks',
+      },
+    });
   });
-});

--- a/examples/track.js
+++ b/examples/track.js
@@ -9,14 +9,14 @@ cio.track(customerId, {
   name: 'purchase',
   data: {
     price: '23.45',
-    product: 'socks'
-  }
+    product: 'socks',
+  },
 });
 
 cio.trackAnonymous({
   name: 'purchase',
   data: {
     price: '23.45',
-    product: 'socks'
-  }
+    product: 'socks',
+  },
 });

--- a/examples/triggerBroadcast.js
+++ b/examples/triggerBroadcast.js
@@ -6,9 +6,10 @@ const campaignId = require('./config').campaignId;
 const cio = new CIO(siteId, apiKey);
 
 const data = {
-  headline: "Roadrunner spotted in Albuquerque!",
+  headline: 'Roadrunner spotted in Albuquerque!',
   date: 1511315635,
-  text: "We've received reports of a roadrunner in your immediate area! Head to your dashboard to view more information!"
-}
+  text:
+    "We've received reports of a roadrunner in your immediate area! Head to your dashboard to view more information!",
+};
 
-cio.triggerBroadcast(campaignId, data, { segment: { id: 7 }});
+cio.triggerBroadcast(campaignId, data, { segment: { id: 7 } });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,95 +1,91 @@
-const Request = require('./request')
-const trackRoot = 'https://track.customer.io/api/v1'
-const apiRoot = 'https://api.customer.io/v1/api'
+const Request = require('./request');
+const trackRoot = 'https://track.customer.io/api/v1';
+const apiRoot = 'https://api.customer.io/v1/api';
 
 const BROADCASTS_ALLOWED_RECIPIENT_FIELDS = {
   ids: ['ids', 'id_ignore_missing'],
   emails: ['emails', 'email_ignore_missing', 'email_add_duplicates'],
   per_user_data: ['per_user_data'],
-  data_file_url: ['data_file_url']
-}
+  data_file_url: ['data_file_url'],
+};
 
 const filterRecipientsDataForField = (recipients, field) => {
-  return BROADCASTS_ALLOWED_RECIPIENT_FIELDS[field]
-    .reduce((obj, field) => {
-      obj[field] = recipients[field]
-      return obj
-    }, {})
-}
+  return BROADCASTS_ALLOWED_RECIPIENT_FIELDS[field].reduce((obj, field) => {
+    obj[field] = recipients[field];
+    return obj;
+  }, {});
+};
 
 module.exports = class CustomerIO {
   constructor(siteid, apikey, defaults) {
-    this.siteid = siteid
-    this.apikey = apikey
-    this.defaults = defaults
-    this.request = new Request(this.siteid, this.apikey, this.defaults)
+    this.siteid = siteid;
+    this.apikey = apikey;
+    this.defaults = defaults;
+    this.request = new Request(this.siteid, this.apikey, this.defaults);
   }
 
   identify(id, data = {}) {
-    return this.request.put(`${trackRoot}/customers/${id}`, data)
+    return this.request.put(`${trackRoot}/customers/${id}`, data);
   }
 
   destroy(id) {
-    return this.request.destroy(`${trackRoot}/customers/${id}`)
+    return this.request.destroy(`${trackRoot}/customers/${id}`);
   }
 
   suppress(id) {
-    return this.request.post(`${trackRoot}/customers/${id}/suppress`)
+    return this.request.post(`${trackRoot}/customers/${id}/suppress`);
   }
 
   track(id, data = {}) {
-    return this.request.post(`${trackRoot}/customers/${id}/events`, data)
+    return this.request.post(`${trackRoot}/customers/${id}/events`, data);
   }
 
   trackAnonymous(data = {}) {
-    return this.request.post(`${trackRoot}/events`, data)
+    return this.request.post(`${trackRoot}/events`, data);
   }
 
   trackPageView(id, path) {
     return this.request.post(`${trackRoot}/customers/${id}/events`, {
       type: 'page',
-      name: path
-    })
+      name: path,
+    });
   }
 
   addDevice(id, device_id, platform, data = {}) {
     return this.request.put(`${trackRoot}/customers/${id}/devices`, {
-      device: Object.assign({ id: device_id, platform }, data)
-    })
+      device: Object.assign({ id: device_id, platform }, data),
+    });
   }
 
   deleteDevice(id, token) {
-    return this.request.destroy(`${trackRoot}/customers/${id}/devices/${token}`)
+    return this.request.destroy(`${trackRoot}/customers/${id}/devices/${token}`);
   }
 
   triggerBroadcast(id, data, recipients) {
-    let payload = {}
-    let customRecipientField =
-      Object
-      .keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS)
-      .find(field => recipients[field])
+    let payload = {};
+    let customRecipientField = Object.keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS).find((field) => recipients[field]);
 
     if (customRecipientField) {
-      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField))
+      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField));
     } else {
       payload = {
         data,
-        recipients
+        recipients,
       };
     }
 
-    return this.request.post(`${apiRoot}/campaigns/${id}/triggers`, payload)
+    return this.request.post(`${apiRoot}/campaigns/${id}/triggers`, payload);
   }
 
   addToSegment(segmentId, customerIds = []) {
     return this.request.post(`${trackRoot}/segments/${segmentId}/add_customers`, {
-      ids: customerIds
-    })
+      ids: customerIds,
+    });
   }
 
   removeFromSegment(segmentId, customerIds = []) {
     return this.request.post(`${trackRoot}/segments/${segmentId}/remove_customers`, {
-      ids: customerIds
-    })
+      ids: customerIds,
+    });
   }
-}
+};

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,71 +1,71 @@
-const request = require('request')
-const TIMEOUT = 10000
+const request = require('request');
+const TIMEOUT = 10000;
 
 class Request {
   constructor(siteid, apikey, defaults) {
-    this.siteid = siteid
-    this.apikey = apikey
-    this.defaults = Object.assign({
-      timeout: TIMEOUT
-    }, defaults)
-    this.auth = `Basic ${Buffer.from(
-      `${this.siteid}:${this.apikey}`,
-      'utf8'
-    ).toString('base64')}`
-    this._request = request.defaults(this.defaults)
+    this.siteid = siteid;
+    this.apikey = apikey;
+    this.defaults = Object.assign(
+      {
+        timeout: TIMEOUT,
+      },
+      defaults,
+    );
+    this.auth = `Basic ${Buffer.from(`${this.siteid}:${this.apikey}`, 'utf8').toString('base64')}`;
+    this._request = request.defaults(this.defaults);
   }
 
   options(uri, method, data) {
     const headers = {
       Authorization: this.auth,
-      'Content-Type': 'application/json'
-    }
-    const body = data ? JSON.stringify(data) : null
-    const options = { method, uri, headers, body }
+      'Content-Type': 'application/json',
+    };
+    const body = data ? JSON.stringify(data) : null;
+    const options = { method, uri, headers, body };
 
-    if (!body) delete options.body
+    if (!body) delete options.body;
 
-    return options
+    return options;
   }
 
   handler(options) {
     return new Promise((resolve, reject) => {
       this._request(options, (error, response, body) => {
-        if (error) return reject(error)
+        if (error) return reject(error);
 
-        let json = null
+        let json = null;
         try {
-          if (body) json = JSON.parse(body)
+          if (body) json = JSON.parse(body);
         } catch (e) {
-          const message = `Unable to parse JSON. Error: ${e} \nBody:\n ${body}`
-          return reject(new Error(message))
+          const message = `Unable to parse JSON. Error: ${e} \nBody:\n ${body}`;
+          return reject(new Error(message));
         }
 
         if (response.statusCode == 200 || response.statusCode == 201) {
-          resolve(json)
+          resolve(json);
         } else {
           reject({
             message: (json && json.meta && json.meta.error) || 'Unknown error',
             statusCode: response.statusCode,
             response: response,
-            body: body
-          })
+            body: body,
+          });
         }
-      })
-    })
+      });
+    });
   }
 
   put(uri, data = {}) {
-    return this.handler(this.options(uri, 'PUT', data))
+    return this.handler(this.options(uri, 'PUT', data));
   }
 
   destroy(uri) {
-    return this.handler(this.options(uri, 'DELETE'))
+    return this.handler(this.options(uri, 'DELETE'));
   }
 
   post(uri, data = {}) {
-    return this.handler(this.options(uri, 'POST', data))
+    return this.handler(this.options(uri, 'POST', data));
   }
 }
 
-module.exports = Request
+module.exports = Request;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "ava": "^0.25.0",
     "nyc": "^11.4.1",
+    "prettier": "2.2.0",
     "sinon": "^4.3.0"
   },
   "homepage": "https://github.com/customerio/customerio-node",

--- a/test/index.js
+++ b/test/index.js
@@ -1,208 +1,174 @@
-const test = require('ava')
-const sinon = require('sinon')
-const CIO = require('../lib')
+const test = require('ava');
+const sinon = require('sinon');
+const CIO = require('../lib');
 
-const trackRoot = 'https://track.customer.io/api/v1'
-const apiRoot = 'https://api.customer.io/v1/api'
+const trackRoot = 'https://track.customer.io/api/v1';
+const apiRoot = 'https://api.customer.io/v1/api';
 
-test.beforeEach(t => {
-  t.context.client = new CIO(123, 'abc')
-})
+test.beforeEach((t) => {
+  t.context.client = new CIO(123, 'abc');
+});
 
-test('constructor sets necessary variables', t => {
-  t.is(t.context.client.siteid, 123)
-  t.is(t.context.client.apikey, 'abc')
-  t.truthy(t.context.client.request)
-  t.is(t.context.client.request.siteid, 123)
-  t.is(t.context.client.request.apikey, 'abc')
-})
+test('constructor sets necessary variables', (t) => {
+  t.is(t.context.client.siteid, 123);
+  t.is(t.context.client.apikey, 'abc');
+  t.truthy(t.context.client.request);
+  t.is(t.context.client.request.siteid, 123);
+  t.is(t.context.client.request.apikey, 'abc');
+});
 
-test('#identify works', t => {
-  sinon.stub(t.context.client.request, 'put')
-  t.context.client.identify(1)
+test('#identify works', (t) => {
+  sinon.stub(t.context.client.request, 'put');
+  t.context.client.identify(1);
+  t.truthy(t.context.client.request.put.calledWith(`${trackRoot}/customers/1`, {}));
+});
+
+test('#destroy works', (t) => {
+  sinon.stub(t.context.client.request, 'destroy');
+  t.context.client.destroy(1);
+  t.truthy(t.context.client.request.destroy.calledWith(`${trackRoot}/customers/1`));
+});
+
+test('#suppress works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.suppress(1);
+  t.truthy(t.context.client.request.post.calledWith(`${trackRoot}/customers/1/suppress`));
+});
+
+test('#track with customer id works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.track(1, { data: 'yep' });
   t.truthy(
-    t.context.client.request.put.calledWith(`${trackRoot}/customers/1`, {})
-  )
-})
+    t.context.client.request.post.calledWith(`${trackRoot}/customers/1/events`, {
+      data: 'yep',
+    }),
+  );
+});
 
-test('#destroy works', t => {
-  sinon.stub(t.context.client.request, 'destroy')
-  t.context.client.destroy(1)
-  t.truthy(
-    t.context.client.request.destroy.calledWith(`${trackRoot}/customers/1`)
-  )
-})
-
-test('#suppress works', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.suppress(1)
-  t.truthy(
-    t.context.client.request.post.calledWith(`${trackRoot}/customers/1/suppress`)
-  )
-})
-
-test('#track with customer id works', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.track(1, { data: 'yep' })
-  t.truthy(
-    t.context.client.request.post.calledWith(
-      `${trackRoot}/customers/1/events`,
-      {
-        data: 'yep'
-      }
-    )
-  )
-})
-
-test('#trackAnonymous works', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.trackAnonymous({ data: 'yep' })
+test('#trackAnonymous works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.trackAnonymous({ data: 'yep' });
   t.truthy(
     t.context.client.request.post.calledWith(`${trackRoot}/events`, {
-      data: 'yep'
-    })
-  )
-})
+      data: 'yep',
+    }),
+  );
+});
 
-test('#trackPageView works', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.trackPageView(1, '#home')
+test('#trackPageView works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.trackPageView(1, '#home');
   t.truthy(
-    t.context.client.request.post.calledWith(
-      `${trackRoot}/customers/1/events`,
-      {
-        type: 'page',
-        name: '#home'
-      }
-    )
-  )
-})
+    t.context.client.request.post.calledWith(`${trackRoot}/customers/1/events`, {
+      type: 'page',
+      name: '#home',
+    }),
+  );
+});
 
-test('#triggerBroadcast works', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.triggerBroadcast(1, { type: 'data' }, { type: 'recipients' })
+test('#triggerBroadcast works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { type: 'recipients' });
   t.truthy(
-    t.context.client.request.post.calledWith(
-      `${apiRoot}/campaigns/1/triggers`,
-      {
-        data: { type: 'data' },
-        recipients: { type: 'recipients' }
-      }
-    )
-  )
-})
+    t.context.client.request.post.calledWith(`${apiRoot}/campaigns/1/triggers`, {
+      data: { type: 'data' },
+      recipients: { type: 'recipients' },
+    }),
+  );
+});
 
-test('#triggerBroadcast works with emails', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.triggerBroadcast(1, { type: 'data' }, { emails: ['test@email.com'], email_ignore_missing: true, email_add_duplicates: true })
+test('#triggerBroadcast works with emails', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(
+    1,
+    { type: 'data' },
+    { emails: ['test@email.com'], email_ignore_missing: true, email_add_duplicates: true },
+  );
   t.truthy(
-    t.context.client.request.post.calledWith(
-      `${apiRoot}/campaigns/1/triggers`,
-      {
-        data: { type: 'data' },
-        emails: ['test@email.com'],
-        email_ignore_missing: true,
-        email_add_duplicates: true,
-      }
-    )
-  )
-})
+    t.context.client.request.post.calledWith(`${apiRoot}/campaigns/1/triggers`, {
+      data: { type: 'data' },
+      emails: ['test@email.com'],
+      email_ignore_missing: true,
+      email_add_duplicates: true,
+    }),
+  );
+});
 
-test('#triggerBroadcast works with ids', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true })
+test('#triggerBroadcast works with ids', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true });
   t.truthy(
-    t.context.client.request.post.calledWith(
-      `${apiRoot}/campaigns/1/triggers`,
-      {
-        data: { type: 'data' },
-        ids: [1],
-        id_ignore_missing: true,
-      }
-    )
-  )
-})
+    t.context.client.request.post.calledWith(`${apiRoot}/campaigns/1/triggers`, {
+      data: { type: 'data' },
+      ids: [1],
+      id_ignore_missing: true,
+    }),
+  );
+});
 
-test('#triggerBroadcast discards extraneous fields', t => {
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.triggerBroadcast(1, { type: 'data' }, { ids: [1], id_ignore_missing: true, emails: ['test@email.com'], exampleField: true })
+test('#triggerBroadcast discards extraneous fields', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(
+    1,
+    { type: 'data' },
+    { ids: [1], id_ignore_missing: true, emails: ['test@email.com'], exampleField: true },
+  );
   t.truthy(
-    t.context.client.request.post.calledWith(
-      `${apiRoot}/campaigns/1/triggers`,
-      {
-        data: { type: 'data' },
-        ids: [1],
-        id_ignore_missing: true,
-      }
-    )
-  )
-})
+    t.context.client.request.post.calledWith(`${apiRoot}/campaigns/1/triggers`, {
+      data: { type: 'data' },
+      ids: [1],
+      id_ignore_missing: true,
+    }),
+  );
+});
 
-test('#addDevice works', t => {
-  sinon.stub(t.context.client.request, 'put')
+test('#addDevice works', (t) => {
+  sinon.stub(t.context.client.request, 'put');
   t.context.client.addDevice(1, 123, 'ios', { primary: true });
   t.truthy(
-    t.context.client.request.put.calledWith(
-      `${trackRoot}/customers/1/devices`, {
-        device: {
-          id: 123,
-          platform: 'ios',
-          primary: true
-        }
-      }
-    )
-  )
-})
+    t.context.client.request.put.calledWith(`${trackRoot}/customers/1/devices`, {
+      device: {
+        id: 123,
+        platform: 'ios',
+        primary: true,
+      },
+    }),
+  );
+});
 
-test('#addDevice works with an empty data parameter', t => {
-  sinon.stub(t.context.client.request, 'put')
+test('#addDevice works with an empty data parameter', (t) => {
+  sinon.stub(t.context.client.request, 'put');
   t.context.client.addDevice(1, 123, 'ios', null);
   t.truthy(
-    t.context.client.request.put.calledWith(
-      `${trackRoot}/customers/1/devices`, {
-        device: {
-          id: 123,
-          platform: 'ios'
-        }
-      }
-    )
-  )
-})
+    t.context.client.request.put.calledWith(`${trackRoot}/customers/1/devices`, {
+      device: {
+        id: 123,
+        platform: 'ios',
+      },
+    }),
+  );
+});
 
-test('#deleteDevice works', t => {
-  sinon.stub(t.context.client.request, 'destroy')
-  t.context.client.deleteDevice(1, 123)
-  t.truthy(
-    t.context.client.request.destroy.calledWith(
-      `${trackRoot}/customers/1/devices/123`
-    )
-  )
-})
+test('#deleteDevice works', (t) => {
+  sinon.stub(t.context.client.request, 'destroy');
+  t.context.client.deleteDevice(1, 123);
+  t.truthy(t.context.client.request.destroy.calledWith(`${trackRoot}/customers/1/devices/123`));
+});
 
-test('#addToSegment works', t => {
-  let ids = ['1', '2', '3']
+test('#addToSegment works', (t) => {
+  let ids = ['1', '2', '3'];
 
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.addToSegment(1, ids)
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.addToSegment(1, ids);
 
-  t.truthy(
-    t.context.client.request.post.calledWith(
-      `${trackRoot}/segments/1/add_customers`,
-      { ids }
-    )
-  )
-})
+  t.truthy(t.context.client.request.post.calledWith(`${trackRoot}/segments/1/add_customers`, { ids }));
+});
 
-test('#removeFromSegment works', t => {
-  let ids = ['1', '2', '3']
+test('#removeFromSegment works', (t) => {
+  let ids = ['1', '2', '3'];
 
-  sinon.stub(t.context.client.request, 'post')
-  t.context.client.removeFromSegment(1, ids)
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.removeFromSegment(1, ids);
 
-  t.truthy(
-    t.context.client.request.post.calledWith(
-      `${trackRoot}/segments/1/remove_customers`,
-      { ids }
-    )
-  )
-})
+  t.truthy(t.context.client.request.post.calledWith(`${trackRoot}/segments/1/remove_customers`, { ids }));
+});

--- a/test/request.js
+++ b/test/request.js
@@ -1,149 +1,145 @@
-const test = require('ava')
-const sinon = require('sinon')
-const Request = require('../lib/request')
+const test = require('ava');
+const sinon = require('sinon');
+const Request = require('../lib/request');
 
 // setup & fixture data
-const siteId = 123
-const apiKey = 'abc'
-const uri = 'https://track.customer.io/api/v1/customers/1'
-const data = { first_name: 'Bruce', last_name: 'Wayne' }
-const auth = `Basic ${Buffer.from(`${siteId}:${apiKey}`).toString('base64')}`
+const siteId = 123;
+const apiKey = 'abc';
+const uri = 'https://track.customer.io/api/v1/customers/1';
+const data = { first_name: 'Bruce', last_name: 'Wayne' };
+const auth = `Basic ${Buffer.from(`${siteId}:${apiKey}`).toString('base64')}`;
 const baseOptions = {
   uri,
   headers: {
     Authorization: auth,
-    'Content-Type': 'application/json'
-  }
-}
+    'Content-Type': 'application/json',
+  },
+};
 
-test.beforeEach(t => {
-  t.context.req = new Request(123, 'abc', { timeout: 5000 })
-})
+test.beforeEach((t) => {
+  t.context.req = new Request(123, 'abc', { timeout: 5000 });
+});
 
 // tests begin here
-test('constructor sets all properties correctly', t => {
-  t.is(t.context.req.siteid, 123)
-  t.is(t.context.req.apikey, 'abc')
-  t.deepEqual(t.context.req.defaults, { timeout: 5000 })
-  t.is(t.context.req.auth, auth)
-})
+test('constructor sets all properties correctly', (t) => {
+  t.is(t.context.req.siteid, 123);
+  t.is(t.context.req.apikey, 'abc');
+  t.deepEqual(t.context.req.defaults, { timeout: 5000 });
+  t.is(t.context.req.auth, auth);
+});
 
-test('constructor sets default timeout correctly', t => {
-  const req = new Request()
-  t.deepEqual(req.defaults, { timeout: 10000 })
-})
+test('constructor sets default timeout correctly', (t) => {
+  const req = new Request();
+  t.deepEqual(req.defaults, { timeout: 10000 });
+});
 
-test('#options returns a correctly formatted object', t => {
-  const expectedOptions = Object.assign(baseOptions, { method: 'POST' })
-  const resultOptions = t.context.req.options(uri, 'POST')
+test('#options returns a correctly formatted object', (t) => {
+  const expectedOptions = Object.assign(baseOptions, { method: 'POST' });
+  const resultOptions = t.context.req.options(uri, 'POST');
 
-  t.deepEqual(resultOptions, expectedOptions)
-})
+  t.deepEqual(resultOptions, expectedOptions);
+});
 
 const putOptions = Object.assign({}, baseOptions, {
   method: 'PUT',
-  body: JSON.stringify(data)
-})
+  body: JSON.stringify(data),
+});
 
-test('#handler returns a promise', t => {
-  const promise = t.context.req.handler(putOptions)
-  t.context.req._request = () => {}
-  t.is(promise.constructor.name, 'Promise')
-})
+test('#handler returns a promise', (t) => {
+  const promise = t.context.req.handler(putOptions);
+  t.context.req._request = () => {};
+  t.is(promise.constructor.name, 'Promise');
+});
 
-test('#handler makes a request and resolves a promise on success', t => {
-  const body = {}
+test('#handler makes a request and resolves a promise on success', (t) => {
+  const body = {};
   t.context.req._request = (options, cb) => {
-    cb(null, { statusCode: 200 }, JSON.stringify(body))
-  }
-  return t.context.req.handler(putOptions).then(res => t.deepEqual(res, body))
-})
+    cb(null, { statusCode: 200 }, JSON.stringify(body));
+  };
+  return t.context.req.handler(putOptions).then((res) => t.deepEqual(res, body));
+});
 
-test('#handler makes a request and rejects with an error on failure', t => {
+test('#handler makes a request and rejects with an error on failure', (t) => {
   const customOptions = Object.assign({}, baseOptions, {
     uri: 'https://track.customer.io/api/v1/customers/1/events',
-    body: JSON.stringify({ title: 'The Batman' })
-  })
+    body: JSON.stringify({ title: 'The Batman' }),
+  });
 
-  const message = 'test error message'
-  const body = { meta: { error: message } }
+  const message = 'test error message';
+  const body = { meta: { error: message } };
 
   t.context.req._request = (options, cb) => {
-    cb(null, { statusCode: 400 }, JSON.stringify(body))
-  }
+    cb(null, { statusCode: 400 }, JSON.stringify(body));
+  };
 
-  return t.context.req
-    .handler(customOptions)
-    .catch(err => t.is(err.message, message))
-})
+  return t.context.req.handler(customOptions).catch((err) => t.is(err.message, message));
+});
 
-test('#handler makes a request and rejects with `null` as body', t => {
+test('#handler makes a request and rejects with `null` as body', (t) => {
   const customOptions = Object.assign({}, baseOptions, {
     uri: 'https://track.customer.io/api/v1/customers/1/events',
-    body: JSON.stringify({ title: 'The Batman' })
-  })
+    body: JSON.stringify({ title: 'The Batman' }),
+  });
 
   t.context.req._request = (options, cb) => {
-    cb(null, { statusCode: 500 })
-  }
+    cb(null, { statusCode: 500 });
+  };
 
-  return t.context.req
-    .handler(customOptions)
-    .catch(err => t.is(err.message, 'Unknown error'))
-})
+  return t.context.req.handler(customOptions).catch((err) => t.is(err.message, 'Unknown error'));
+});
 
-test('#handler makes a request and rejects with timeout error', t => {
+test('#handler makes a request and rejects with timeout error', (t) => {
   const customOptions = Object.assign({}, baseOptions, {
     method: 'PUT',
     body: JSON.stringify(data),
-    timeout: 1
-  })
+    timeout: 1,
+  });
 
-  const message = 'test error message'
-  const body = { meta: { error: message } }
+  const message = 'test error message';
+  const body = { meta: { error: message } };
 
   return t.context.req
     .handler(customOptions)
     .then(t.fail)
-    .catch(err => t.is(err.message, 'ETIMEDOUT'))
-})
+    .catch((err) => t.is(err.message, 'ETIMEDOUT'));
+});
 
-test('#put calls the handler, makes PUT request with the correct args', t => {
-  sinon.stub(t.context.req, 'handler')
-  t.context.req.put(uri, data)
-  t.truthy(t.context.req.handler.calledWith(putOptions))
-})
+test('#put calls the handler, makes PUT request with the correct args', (t) => {
+  sinon.stub(t.context.req, 'handler');
+  t.context.req.put(uri, data);
+  t.truthy(t.context.req.handler.calledWith(putOptions));
+});
 
-test('#put returns the promise generated by the handler', t => {
-  const promise = t.context.req.put(uri, data)
-  t.is(promise.constructor.name, 'Promise')
-})
+test('#put returns the promise generated by the handler', (t) => {
+  const promise = t.context.req.put(uri, data);
+  t.is(promise.constructor.name, 'Promise');
+});
 
-const deleteOptions = Object.assign({}, baseOptions, { method: 'DELETE' })
+const deleteOptions = Object.assign({}, baseOptions, { method: 'DELETE' });
 
-test('#destroy calls the handler, makes a DELETE request with the correct args', t => {
-  sinon.stub(t.context.req, 'handler')
-  t.context.req.destroy(uri)
-  t.truthy(t.context.req.handler.calledWith(deleteOptions))
-})
+test('#destroy calls the handler, makes a DELETE request with the correct args', (t) => {
+  sinon.stub(t.context.req, 'handler');
+  t.context.req.destroy(uri);
+  t.truthy(t.context.req.handler.calledWith(deleteOptions));
+});
 
-test('#destroy returns the promise generated by the handler', t => {
-  const promise = t.context.req.destroy(uri)
-  t.is(promise.constructor.name, 'Promise')
-})
+test('#destroy returns the promise generated by the handler', (t) => {
+  const promise = t.context.req.destroy(uri);
+  t.is(promise.constructor.name, 'Promise');
+});
 
 const postOptions = Object.assign({}, baseOptions, {
   method: 'POST',
-  body: JSON.stringify(data)
-})
+  body: JSON.stringify(data),
+});
 
-test('#post calls the handler, makes a POST request with the correct args', t => {
-  sinon.stub(t.context.req, 'handler')
-  t.context.req.post(uri, data)
-  t.truthy(t.context.req.handler.calledWith(postOptions))
-})
+test('#post calls the handler, makes a POST request with the correct args', (t) => {
+  sinon.stub(t.context.req, 'handler');
+  t.context.req.post(uri, data);
+  t.truthy(t.context.req.handler.calledWith(postOptions));
+});
 
-test('#post returns the promise generated by the handler', t => {
-  const promise = t.context.req.post(uri)
-  t.is(promise.constructor.name, 'Promise')
-})
+test('#post returns the promise generated by the handler', (t) => {
+  const promise = t.context.req.post(uri);
+  t.is(promise.constructor.name, 'Promise');
+});


### PR DESCRIPTION
This PR makes two changes:

- One, it introduces prettier and runs it for the `lib`, `test`, and `examples` directories.
- Two, it updates the Node.js versions that we're testing against to the current ones (removes `carbon` and `boron` whose EOL are in the past)