### PR TITLE
Add api.js and track.js files at the root level, remove exports

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,0 +1,2 @@
+const API = require('./lib/api');
+module.exports = API;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,0 @@
-const Track = require('./track');
-module.exports = Track;

--- a/package.json
+++ b/package.json
@@ -28,12 +28,7 @@
     "node"
   ],
   "license": "MIT",
-  "main": "lib",
-  "exports": {
-    ".": "./lib/index.js",
-    "./api": "./lib/api.js",
-    "./track": "./lib/track.js"
-  },
+  "main": "track",
   "repository": "customerio/customerio-node",
   "scripts": {
     "test": "nyc ava"

--- a/test/api.js
+++ b/test/api.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const sinon = require('sinon');
-const { APIClient, SendEmailRequest } = require('../lib/api');
+const { APIClient, SendEmailRequest } = require('../api');
 
 const apiRoot = 'https://api.customer.io/v1';
 

--- a/test/track.js
+++ b/test/track.js
@@ -1,6 +1,6 @@
 const test = require('ava');
 const sinon = require('sinon');
-const CIO = require('../lib');
+const CIO = require('../track');
 
 const trackRoot = 'https://track.customer.io/api/v1';
 const apiRoot = 'https://api.customer.io/v1/api';

--- a/track.js
+++ b/track.js
@@ -1,0 +1,2 @@
+const Track = require('./lib/track');
+module.exports = Track;


### PR DESCRIPTION
Follow up to #34

We used the `exports` field in `package.json` which isn't well supported in older versions, including older 12.x.x versions. That breaks imports such as `customerio-node/api`.

This PR addresses that by adding `api.js` and `track.js` files at the root level that just re-export the `api.js` and `track.js` files from within the `lib` folder. I've also updated `main` in `package.json` to `track.js`.