### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## [2.0.0]
 ### Changed
-- (Breaking) Move triggerBroadcast method from Track to API class (#46)
+- (Breaking) Move triggerBroadcast method from Track to API class ([#46](https://github.com/customerio/customerio-node/pull/46))
 
 ## [1.1.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [2.0.0]
+### Changed
+- (Breaking) Move triggerBroadcast method from Track to API class (#46)
+
 ## [1.1.0]
 ### Added
 - Support for the EU region

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-node",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
Bumps the version to 2.0.0 after this breaking change:

#46 Move triggerBroadcast method to API class 