### PR TITLE
Prepare the release for 2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,12 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+## [2.1.0]
 
+### Changed
 - Upgrade `ini` from 1.3.5 to 1.3.8 ([#36](https://github.com/customerio/customerio-node/pull/36))
+
+### Added
 - Convert `customerio-node` to Typescript ([#49](https://github.com/customerio/customerio-node/pull/49))
 
 ## [2.0.0]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-node",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
This updates the version and changelog for `2.1.0`.

Contained in this release:
- Update to typescript #49 
- Update to `ini` for a security vulnerability (dev only) #36 