### PR TITLE
Test with npm and not yarn

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,5 @@ jobs:
           key: customerio-${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
           restore-keys: |
             customerio-${{ matrix.node }}
-      - name: install yarn
-        run: |
-          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-          sudo apt-get update && sudo apt-get install --no-install-recommends yarn -y
-      - run: yarn install
-      - run: yarn test
+      - run: npm ci
+      - run: npm test


### PR DESCRIPTION
We don't use yarn for the development of this package, but we currently install dependencies and test with yarn in CI. This seems to be a holdover from an old Travis CI configuration, but we can just use npm now.