### PR TITLE
fix to export typescript files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,5 @@ jobs:
           restore-keys: |
             customerio-${{ matrix.node }}
       - run: npm ci
+      - run: npm run build
       - run: npm test

--- a/api.js
+++ b/api.js
@@ -1,2 +1,0 @@
-const API = require('./dist/api');
-module.exports = API;

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "node"
   ],
   "license": "MIT",
-  "main": "track",
+  "main": "dist/track.js",
+  "typings": "dist/track.d.ts",
   "repository": "customerio/customerio-node",
   "scripts": {
     "test": "nyc ava",

--- a/regions.js
+++ b/regions.js
@@ -1,2 +1,0 @@
-const Regions = require('./dist/regions');
-module.exports = Regions;

--- a/track.js
+++ b/track.js
@@ -1,2 +1,0 @@
-const Track = require('./dist/track');
-module.exports = Track.default;


### PR DESCRIPTION
Fixes #54 

# Changes
* Removes unnecessary javascript files
* Updates `package.json` main to point to the dist version of track
* Updates `package.json` to include typings entrypoint
* Retains backwards compat with existing entrypoint so users will notice no change in importing.

# Typescript notes
A future PR should include an `index.ts` file that exports all of the relevant things, including the `api.ts` so that this module can more easily be utilized for sending transactional emails. It's also healthy to have a single entrypoint for a module.
It's important to note though that this would be a breaking change (perhaps a 3.0.0) as it would change how the module is imported.

Current
```
import CIO from 'customerio-node';
```

Future PR:
For tracking
```
import { TrackClient } from 'customerio-node';
```

For API (transactional emails)
```
import { APIClient } from 'customerio-node';
```