### PR TITLE
Fix typings after typescript conversion

### DIFF
--- a/api.d.ts
+++ b/api.d.ts
@@ -1,0 +1,3 @@
+import API from './dist/api';
+
+export = API;

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,14 +441,12 @@
     "@types/caseless": {
       "version": "0.12.2",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w==",
-      "dev": true
+      "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
     },
     "@types/node": {
       "version": "14.14.41",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.41.tgz",
-      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g==",
-      "dev": true
+      "integrity": "sha512-dueRKfaJL4RTtSa7bWeTK1M+VH+Gns73oCgzvYfHZywRCoPSd8EkXBL0mZ9unPTveBn+D9phZBaxuzpwjWkW0g=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -460,7 +458,6 @@
       "version": "2.48.5",
       "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.5.tgz",
       "integrity": "sha512-/LO7xRVnL3DxJ1WkPGDQrp4VTV1reX9RkC85mJ+Qzykj2Bdw+mG15aAfDahc76HtknjzE16SX/Yddn6MxVbmGQ==",
-      "dev": true,
       "requires": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -472,7 +469,6 @@
           "version": "2.5.1",
           "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.1.tgz",
           "integrity": "sha512-m21N3WOmEEURgk6B9GLOE4RuWOFf28Lhh9qGYeNlGq4VDXUlJy2th2slBNU8Gp8EzloYZOibZJ7t5ecIrFSjVA==",
-          "dev": true,
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "^1.0.6",
@@ -493,8 +489,7 @@
     "@types/tough-cookie": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
-      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==",
-      "dev": true
+      "integrity": "sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A=="
     },
     "acorn": {
       "version": "8.1.1",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   },
   "bugs": "https://github.com/customerio/customerio-node/issues",
   "dependencies": {
+    "@types/request": "^2.48.5",
     "request": "^2.58.0"
   },
   "devDependencies": {
     "@types/node": "^14.14.41",
-    "@types/request": "^2.48.5",
     "@types/sinon": "^10.0.0",
     "ava": "^3.15.0",
     "nyc": "^15.1.0",
@@ -62,6 +62,7 @@
   ],
   "license": "MIT",
   "main": "track",
+  "types": "track.d.ts",
   "repository": "customerio/customerio-node",
   "scripts": {
     "test": "nyc ava",

--- a/regions.d.ts
+++ b/regions.d.ts
@@ -1,0 +1,3 @@
+import * as Regions from './dist/regions';
+
+export = Regions;

--- a/track.d.ts
+++ b/track.d.ts
@@ -1,0 +1,3 @@
+import TrackClient from './dist/track';
+
+export = TrackClient;


### PR DESCRIPTION
This addresses #54 and attempts to implement the purpose of #55 while also being backwards compatible. While the types are correct, the typings exported in the package were inaccessible to clients writing code in Typescript.

This adds some new `*.d.ts` files for the default Track class, API class, and Region exports. This allows Typescript consumers to use the package correctly, while also allowing existing JS-based clients to not have to implement any changes.