### PR TITLE
Restructure the package and update documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
 - (**BREAKING**) Return an `Error` instance for non-`2XX` status codes ([#62](https://github.com/customerio/customerio-node/pull/62))
   - We don't expect this to break many consumers of `customerio-node`. Unless you were using `instanceof` to check the type of error returned from track or api methods, you don't need to make any changed. `message`, `statusCode`, `response`, and `body` are still accessible as properties on the error.
   
+- (**BREAKING**) Restructure the package to have a single entry point, rather than three. This is more of a standard package structure, and is more future-proof. ([#63](https://github.com/customerio/customerio-node/pull/63))
+  
 - Return a readable message when the server returns an array of errors instead of `Unknown error` ([#62](https://github.com/customerio/customerio-node/pull/62))
 
 ## [2.1.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
   
 - Return a readable message when the server returns an array of errors instead of `Unknown error` ([#62](https://github.com/customerio/customerio-node/pull/62))
 
+## [3.0.0]
+
+### Changed
+- (Breaking) `trackAnonymous` now requires an `anonymous_id` and cannot trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as "invite events". 
+
 ## [2.1.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -102,12 +102,14 @@ cio.track(1, {
 
 ---
 
-### cio.trackAnonymous(data)
+### cio.trackAnonymous(anonymous_id, data)
 
-Anonymous event tracking does not require a customer ID and Customer.io will not associate these events with a tracked profile.
+Track an anonymous event. An anonymous event is an event associated with a person you haven't identified, requiring an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
+
+Anonymous events cannot trigger campaigns. If you associate an event with a person within 72 hours of the event timestamp, however, a formerly anonymous event can trigger a campaign.
 
 ```javascript
-cio.trackAnonymous({
+cio.trackAnonymous(anonymous_id, {
   name: "updated",
   data: {
     updated: true,
@@ -118,6 +120,7 @@ cio.trackAnonymous({
 
 #### Options
 
+- **anonymous_id**: String or number (required)
 - **data**: Object (required)
   - _name_ is a required key on the Object
   - _data_ is an optional key for additional data sent over with the event

--- a/README.md
+++ b/README.md
@@ -15,21 +15,20 @@ npm i --save customerio-node
 To start using the library, you first need to create an instance of the CIO class:
 
 ```javascript
-const CIO = require("customerio-node");
-const { RegionUS, RegionEU } = require("customerio-node/regions");
-let cio = new CIO(siteId, apiKey, { region: RegionUS }, [defaults]);
+const { TrackClient, RegionUS, RegionEU } = require("customerio-node");
+let cio = new TrackClient(siteId, apiKey, { region: RegionUS }, [defaults]);
 ```
 
-Both the `siteId` and `apiKey` are **required** in order to create a Basic Authorization header, allowing us to associate the data with your account.
+Both the `siteId` and `apiKey` are **required** to create a Basic Authorization header, allowing us to associate the data with your account.
 
-Your account `region` is optional. If you do not specify your region, we assume that your account is based in the US (`RegionUS`). If your account is based in the EU and you do not provide the correct region, we'll route requests from the US to `RegionEU` accordingly, however this may cause data to be logged in the US.
+Your account `region` is optional. If you do not specify your region, the default will be the US region (`RegionUS`). If your account is in the EU and you do not provide the correct region, we'll route requests from the US to `RegionEU` accordingly. This may cause data to be logged in the US.
 
-Optionally you can pass `defaults` as an object that will be passed to the underlying request instance. A list of the possible options are listed [here](https://nodejs.org/api/http.html#http_http_request_options_callback).
+Optionally you can pass `defaults` as an object that will forwarded to the underlying request instance. The [node `http` docs](https://nodejs.org/api/http.html#http_http_request_options_callback) has a list of the possible options.
 
 This is useful to override the default 10s timeout. Example:
 
 ```
-const cio = new CIO(123, 'abc', {
+const cio = new TrackClient(123, 'abc', {
   timeout: 5000
 });
 ```
@@ -74,7 +73,7 @@ cio.destroy(1);
 
 ### cio.track(id, data)
 
-The track method will trigger events within Customer.io. When sending data along with your event, it is required to send a name key/value pair in you data object.
+The track method will trigger events within Customer.io. Customer.io requires a name key/value pair in you data object when sending data along with your event.
 
 **Simple event tracking**
 
@@ -105,7 +104,7 @@ cio.track(1, {
 
 ### cio.trackAnonymous(data)
 
-Anonymous event tracking does not require a customer ID and these events will not be associated with a tracked profile in Customer.io
+Anonymous event tracking does not require a customer ID and Customer.io will not associate these events with a tracked profile.
 
 ```javascript
 cio.trackAnonymous({
@@ -196,6 +195,22 @@ cio.identify(customerId, { first_name: "Finn" }).then(() => {
 });
 ```
 
+or use `async/await`:
+
+```javascript
+const customerId = 1;
+
+await cio.identify(customerId, { first_name: "Finn" });
+
+return cio.track(customerId, {
+  name: "updated",
+  data: {
+    updated: true,
+    plan: "free",
+  },
+});
+```
+
 ### Transactional API
 
 To use the Customer.io [Transactional API](https://customer.io/docs/transactional-api), import our API client and initialize it with an [app key](https://customer.io/docs/managing-credentials#app-api-keys).
@@ -212,9 +227,8 @@ Use `sendEmail` referencing your request to send a transactional message. [Learn
 
 ```javascript
 const fs = require("fs");
-const { APIClient, SendEmailRequest } = require("customerio-node/api");
-const { RegionUS, RegionEU } = require("customerio-node/regions");
-let api = new APIClient("app-key", { region: RegionUS });
+const { APIClient, SendEmailRequest, RegionUS, RegionEU } = require("customerio-node");
+const api = new APIClient("app-key", { region: RegionUS });
 
 const request = new SendEmailRequest({
   to: "person@example.com",

--- a/api.d.ts
+++ b/api.d.ts
@@ -1,3 +1,0 @@
-import API from './dist/api';
-
-export = API;

--- a/api.js
+++ b/api.js
@@ -1,2 +1,0 @@
-const API = require('./dist/api');
-module.exports = API;

--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -5,6 +5,7 @@ const config = {
   customerId: '1',
   customerEmail: 'ami@customer.io',
   transactionalMessageId: '1',
+  anonymousId: 'anon',
   campaignId: '1',
 };
 

--- a/examples/destroy.js
+++ b/examples/destroy.js
@@ -1,10 +1,9 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.destroy(customerId);

--- a/examples/identify.js
+++ b/examples/identify.js
@@ -1,17 +1,14 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.identify(customerId, {
   email: 'customer@example.com',
   created_at: 1361205308,
   first_name: 'Bob-node-example',
   plan: 'basic',
-  ohno:
-    'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
 });

--- a/examples/promises.js
+++ b/examples/promises.js
@@ -1,11 +1,10 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio
   .identify(customerId, {

--- a/examples/track.js
+++ b/examples/track.js
@@ -4,6 +4,7 @@ const { TrackClient, RegionUS, RegionEU } = require('../index');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
+const anonymousId = require('./config').anonymousId;
 const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.track(customerId, {
@@ -14,7 +15,7 @@ cio.track(customerId, {
   },
 });
 
-cio.trackAnonymous({
+cio.trackAnonymous(anonymousId, {
   name: 'purchase',
   data: {
     price: '23.45',

--- a/examples/track.js
+++ b/examples/track.js
@@ -1,11 +1,10 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.track(customerId, {
   name: 'purchase',

--- a/examples/trackPageView.js
+++ b/examples/trackPageView.js
@@ -1,10 +1,9 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.trackPageView(customerId, '#home');

--- a/examples/transactional-email.js
+++ b/examples/transactional-email.js
@@ -1,10 +1,8 @@
 const fs = require('fs');
 
-// In actual use require the node module: let APIClient = require('customerio-node/api');
-const { APIClient, SendEmailRequest } = require('../api');
-
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
+// In actual use require the node module:
+// const { APIClient, SendEmailRequest } = require('customerio-node');
+const { APIClient, SendEmailRequest } = require('../index');
 const { appKey, transactionalMessageId, customerEmail } = require('./config');
 
 const api = new APIClient(appKey, { region: RegionUS });

--- a/examples/triggerBroadcast.js
+++ b/examples/triggerBroadcast.js
@@ -1,11 +1,10 @@
-let CIO = require('../track');
-// In actual use require the node module: let CIO = require('customerio-node');
+const { TrackClient, RegionUS, RegionEU } = require('../index');
+// In actual use require the node module:
+// const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const campaignId = require('./config').campaignId;
-// In actual use, specify your specific region and require node module: const { RegionUS, RegionEU } = require('customerio-node/regions')
-const { RegionUS, RegionEU } = require('../regions');
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 const data = {
   headline: 'Roadrunner spotted in Albuquerque!',

--- a/examples/typescript.ts
+++ b/examples/typescript.ts
@@ -1,11 +1,10 @@
-import CIO from '../track';
-// In actual use import the node module: import CIO from 'customerio-node';
+import { TrackClient, RegionUS, RegionEU } from '../index';
+// In actual use import the node module:
+// import { TrackClient, RegionUS, RegionEU } from 'customerio-node';
 import { siteId, apiKey, customerId } from './config';
-// In actual use, specify your specific region and import the node module: const { RegionUS, RegionEU } from 'customerio-node/regions)
-import { RegionUS, RegionEU } from '../regions';
-const cio = new CIO(siteId, apiKey, { region: RegionUS });
+const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
-cio.identify(1005, {
+cio.identify(customerId, {
   email: 'customer@example.com',
   created_at: 1361205308,
   first_name: 'Bob-node-example',

--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,3 @@
+export * from './lib/track';
+export * from './lib/api';
+export * from './lib/regions';

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -70,12 +70,16 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/events`, data);
   }
 
-  trackAnonymous(data: RequestData = {}) {
+  trackAnonymous(anonymousId: string | number, data: RequestData = {}) {
+    if (isEmpty(anonymousId)) {
+      throw new MissingParamError('anonymousId');
+    }
+
     if (isEmpty(data.name)) {
       throw new MissingParamError('data.name');
     }
 
-    return this.request.post(`${this.trackRoot}/events`, data);
+    return this.request.post(`${this.trackRoot}/events`, { ...data, anonymous_id: anonymousId });
   }
 
   trackPageView(customerId: string | number, path: string) {

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -12,7 +12,7 @@ class MissingParamError extends Error {
   }
 }
 
-export default class TrackClient {
+export class TrackClient {
   siteid: BasicAuth['siteid'];
   apikey: BasicAuth['apikey'];
   defaults: TrackDefaults;

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "node"
   ],
   "license": "MIT",
-  "main": "track",
-  "types": "track.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "repository": "customerio/customerio-node",
   "scripts": {
     "test": "nyc ava",

--- a/regions.d.ts
+++ b/regions.d.ts
@@ -1,3 +1,0 @@
-import * as Regions from './dist/regions';
-
-export = Regions;

--- a/regions.js
+++ b/regions.js
@@ -1,2 +1,0 @@
-const Regions = require('./dist/regions');
-module.exports = Regions;

--- a/test/track.ts
+++ b/test/track.ts
@@ -118,11 +118,13 @@ ID_INPUTS.forEach(([input, expected]) => {
 
 test('#trackAnonymous works', (t) => {
   sinon.stub(t.context.client.request, 'post');
-  t.throws(() => t.context.client.trackAnonymous(), { message: 'data.name is required' });
-  t.throws(() => t.context.client.trackAnonymous({ data: {} }), { message: 'data.name is required' });
-  t.context.client.trackAnonymous({ name: 'purchase', data: 'yep' });
+  t.throws(() => t.context.client.trackAnonymous(''), { message: 'anonymousId is required' });
+  t.throws(() => t.context.client.trackAnonymous('123'), { message: 'data.name is required' });
+  t.throws(() => t.context.client.trackAnonymous('123', { data: {} }), { message: 'data.name is required' });
+  t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
+      anonymous_id: '123',
       name: 'purchase',
       data: 'yep',
     }),

--- a/test/track.ts
+++ b/test/track.ts
@@ -1,6 +1,6 @@
 import avaTest, { TestInterface } from 'ava';
 import sinon, { SinonStub } from 'sinon';
-import TrackClient from '../lib/track';
+import { TrackClient } from '../lib/track';
 import { RegionUS, RegionEU } from '../lib/regions';
 
 type TestContext = { client: TrackClient };

--- a/track.d.ts
+++ b/track.d.ts
@@ -1,3 +1,0 @@
-import TrackClient from './dist/track';
-
-export = TrackClient;

--- a/track.js
+++ b/track.js
@@ -1,2 +1,0 @@
-const Track = require('./dist/track');
-module.exports = Track.default;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,5 +26,5 @@
     "strictPropertyInitialization": true,
     "target": "es2017"
   },
-  "include": ["lib/**/*"]
+  "include": ["index.ts", "lib/**/*"]
 }


### PR DESCRIPTION
With #62, we had to make a breaking change. Since we're already making a breaking change, let's also restructure the whole package to have a more standard export structure. Generally, packages only have a single entry point, and since `customerio-node` doesn't have a "primary" export (the track API used to be the default, but I don't think it should be anymore), we should export everything at the same level.

At the same time, this also updates the documentation to use active voice more and fixes some examples that got merged in with old PRs.