### PR TITLE
Add support for anonymous events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ All notable changes to this project will be documented in this file.
   
 - Return a readable message when the server returns an array of errors instead of `Unknown error` ([#62](https://github.com/customerio/customerio-node/pull/62))
 
-## [2.2.0]
+## [3.0.0]
 
 ### Changed
 - (Breaking) `trackAnonymous` now requires an `anonymous_id` and cannot trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as "invite events". 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ All notable changes to this project will be documented in this file.
   
 - Return a readable message when the server returns an array of errors instead of `Unknown error` ([#62](https://github.com/customerio/customerio-node/pull/62))
 
+## [2.2.0]
+
+### Changed
+- (Breaking) `trackAnonymous` now requires an `anonymous_id` and cannot trigger campaigns. If you previously used anonymous events to trigger campaigns, you can still do so [directly through the API](https://customer.io/docs/api/#operation/trackAnonymous). We now refer to anonymous events that trigger campaigns as "invite events". 
+
 ## [2.1.1]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -104,7 +104,9 @@ cio.track(1, {
 
 ### cio.trackAnonymous(anonymous_id, data)
 
-Track an anonymous event. An anonymous event is an event associated with a person you haven't identified. The event requires an `anonymous_id` representing the unknown person. When you identify a person, you can set their anonymous_id attribute. If the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
+Track an anonymous event. An anonymous event is an event associated with a person you haven't identified, requiring an `anonymous_id` representing the unknown person and an event `name`. When you identify a person, you can set their `anonymous_id` attribute. If [event merging](https://customer.io/docs/anonymous-events/#turn-on-merging) is turned on in your workspace, and the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
+
+Anonymous events cannot trigger campaigns. If you associate an event with a person within 72 hours of the event timestamp, however, a formerly anonymous event can trigger a campaign.
 
 ```javascript
 cio.trackAnonymous(anonymous_id, {

--- a/README.md
+++ b/README.md
@@ -102,12 +102,12 @@ cio.track(1, {
 
 ---
 
-### cio.trackAnonymous(data)
+### cio.trackAnonymous(anonymous_id, data)
 
-Anonymous event tracking does not require a customer ID and Customer.io will not associate these events with a tracked profile.
+Track an anonymous event. An anonymous event is an event associated with a person you haven't identified. The event requires an `anonymous_id` representing the unknown person. When you identify a person, you can set their anonymous_id attribute. If the attribute matches the `anonymous_id` in one or more events that were logged within the last 30 days, we associate those events with the person.
 
 ```javascript
-cio.trackAnonymous({
+cio.trackAnonymous(anonymous_id, {
   name: "updated",
   data: {
     updated: true,
@@ -118,6 +118,7 @@ cio.trackAnonymous({
 
 #### Options
 
+- **anonymous_id**: String or number (required)
 - **data**: Object (required)
   - _name_ is a required key on the Object
   - _data_ is an optional key for additional data sent over with the event

--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -5,6 +5,7 @@ const config = {
   customerId: '1',
   customerEmail: 'ami@customer.io',
   transactionalMessageId: '1',
+  anonymousId: 'anon',
   campaignId: '1',
 };
 

--- a/examples/track.js
+++ b/examples/track.js
@@ -4,6 +4,7 @@ const { TrackClient, RegionUS, RegionEU } = require('../index');
 const siteId = require('./config').siteId;
 const apiKey = require('./config').apiKey;
 const customerId = require('./config').customerId;
+const anonymousId = require('./config').anonymousId;
 const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
 
 cio.track(customerId, {
@@ -14,7 +15,7 @@ cio.track(customerId, {
   },
 });
 
-cio.trackAnonymous({
+cio.trackAnonymous(anonymousId, {
   name: 'purchase',
   data: {
     price: '23.45',

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -70,12 +70,16 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/events`, data);
   }
 
-  trackAnonymous(data: RequestData = {}) {
+  trackAnonymous(anonymousId: string | number, data: RequestData = {}) {
+    if (isEmpty(anonymousId)) {
+      throw new MissingParamError('anonymousId');
+    }
+
     if (isEmpty(data.name)) {
       throw new MissingParamError('data.name');
     }
 
-    return this.request.post(`${this.trackRoot}/events`, data);
+    return this.request.post(`${this.trackRoot}/events`, { ...data, anonymous_id: anonymousId });
   }
 
   trackPageView(customerId: string | number, path: string) {

--- a/test/track.ts
+++ b/test/track.ts
@@ -118,11 +118,13 @@ ID_INPUTS.forEach(([input, expected]) => {
 
 test('#trackAnonymous works', (t) => {
   sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.trackAnonymous(''), { message: 'anonymousId is required' });
   t.throws(() => t.context.client.trackAnonymous('123'), { message: 'data.name is required' });
   t.throws(() => t.context.client.trackAnonymous('123', { data: {} }), { message: 'data.name is required' });
   t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
+      anonymous_id: '123',
       name: 'purchase',
       data: 'yep',
     }),

--- a/test/track.ts
+++ b/test/track.ts
@@ -118,9 +118,9 @@ ID_INPUTS.forEach(([input, expected]) => {
 
 test('#trackAnonymous works', (t) => {
   sinon.stub(t.context.client.request, 'post');
-  t.throws(() => t.context.client.trackAnonymous(), { message: 'data.name is required' });
-  t.throws(() => t.context.client.trackAnonymous({ data: {} }), { message: 'data.name is required' });
-  t.context.client.trackAnonymous({ name: 'purchase', data: 'yep' });
+  t.throws(() => t.context.client.trackAnonymous('123'), { message: 'data.name is required' });
+  t.throws(() => t.context.client.trackAnonymous('123', { data: {} }), { message: 'data.name is required' });
+  t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
       name: 'purchase',


### PR DESCRIPTION
This PR adds support for sending anonymous events. These anonymous events can later be associated / identified with an existing customer. It'll be a breaking change as we're replacing the old `trackAnonymous` method.

###### Usage

```
const CIO = require("customerio-node");
let cio = new CIO(siteId, apiKey);

cio.trackAnonymous(anon_id, { … });
```

We don't generate anonymous IDs. The user has to generate them and pass them to the `track_anonymous` method.

### Notes

This needs documentation, examples, and README updates before merging.