### PR TITLE
fix: triggerBroadcast example

### DIFF
--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -7,6 +7,7 @@ const config = {
   transactionalMessageId: '1',
   anonymousId: 'anon',
   campaignId: '1',
+  segmentId: '1',
 };
 
 module.exports = config;

--- a/examples/triggerBroadcast.js
+++ b/examples/triggerBroadcast.js
@@ -1,10 +1,10 @@
-const { TrackClient, RegionUS, RegionEU } = require('../index');
+const { APIClient, RegionUS, RegionEU } = require('../index');
 // In actual use require the node module:
 // const { TrackClient, RegionUS, RegionEU } = require('customerio-node');
-const siteId = require('./config').siteId;
-const apiKey = require('./config').apiKey;
+const appKey = require('./config').appKey;
 const campaignId = require('./config').campaignId;
-const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
+const segmentId = require('./config').segmentId;
+const cio = new APIClient(appKey, { region: RegionUS });
 
 const data = {
   headline: 'Roadrunner spotted in Albuquerque!',
@@ -13,4 +13,4 @@ const data = {
     "We've received reports of a roadrunner in your immediate area! Head to your dashboard to view more information!",
 };
 
-cio.triggerBroadcast(campaignId, data, { segment: { id: 7 } });
+cio.triggerBroadcast(campaignId, data, { segment: { id: segmentId } });


### PR DESCRIPTION
In the current example, the `triggerBroadcast` function is being called from `TrackClient` when it should be called from `APIClient`. This PR fixes this example and adds an additional entry to the `config.example.js` file.