### PR TITLE
Add pr trigger for forks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
This emulates customerio/customerio-ruby#71 and adds a `pull_request` trigger so that forks can have their tests run