### PR TITLE
🐛 Fix Content-Length header: use the size in bytes, not the number of chars in the stringified body

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -51,7 +51,7 @@ export default class CIORequest {
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
-      'Content-Length': body ? Buffer.from(body).length : 0,
+      'Content-Length': body ? Buffer.byteLength(body,'utf8') : 0,
     };
 
     return { method, uri, headers, body };

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -51,7 +51,7 @@ export default class CIORequest {
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
-      'Content-Length': body ? body.length : 0,
+      'Content-Length': body ? Buffer.from(body).length : 0,
     };
 
     return { method, uri, headers, body };

--- a/test/request-track-api.ts
+++ b/test/request-track-api.ts
@@ -91,6 +91,23 @@ test('#options returns a correctly formatted object', (t) => {
   t.deepEqual(resultOptions, expectedOptions);
 });
 
+test('#options sets Content-Length using body length in bytes', (t) => {
+  const body = { first_name: 'Wïly Wönka' };
+  const method = 'POST'
+  const expectedOptions = {
+    ...baseOptions,
+    method,
+    headers: {
+      ...baseOptions.headers,
+      'Content-Length': 29,
+    },
+    body: JSON.stringify(body),
+  };
+  const resultOptions = t.context.req.options(uri, method, body);
+
+  t.deepEqual(resultOptions, expectedOptions);
+});
+
 test('#handler returns a promise', (t) => {
   createMockRequest(t.context.httpsReq, 200);
   const promise = t.context.req.handler(putOptions);


### PR DESCRIPTION
Sending special characters in the body, such as "ï", resulted in errors like "Name cannot be blank".
It was because in such case, the Content-Length header has a wrong value: it missed one byte. So the actual body sent to custmoerio was truncated.
"ï" has a length of 1, but it has a weight of 2 bytes. The Content-Length header expect a length in bytes.


