### PR TITLE
Allow `from`, `subject`, and `body` to be overridden on transactional msgs

### DIFF
--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -65,7 +65,13 @@ export class SendEmailRequest {
 
     if ('from' in opts) {
       this.message.from = opts.from;
+    }
+
+    if ('subject' in opts) {
       this.message.subject = opts.subject;
+    }
+
+    if ('body' in opts) {
       this.message.body = opts.body;
     }
   }

--- a/test/api.ts
+++ b/test/api.ts
@@ -77,6 +77,42 @@ test('#sendEmail: without template: success', (t) => {
   t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/email`, req.message));
 });
 
+test('#sendEmail: override from: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendEmailRequest({
+    to: 'test@example.com',
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+    from: 'admin@example.com',
+  });
+  t.context.client.sendEmail(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/email`, req.message));
+});
+
+test('#sendEmail: override subject: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendEmailRequest({
+    to: 'test@example.com',
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+    subject: 'This is a test',
+  });
+  t.context.client.sendEmail(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/email`, req.message));
+});
+
+test('#sendEmail: override body: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendEmailRequest({
+    to: 'test@example.com',
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+    body: 'Hi there!',
+  });
+  t.context.client.sendEmail(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/email`, req.message));
+});
+
 test('#sendEmail: adding attachments with encoding (default)', (t) => {
   sinon.stub(t.context.client.request, 'post');
   let req = new SendEmailRequest({ to: 'test@example.com', identifiers: { id: '2' }, transactional_message_id: 1 });


### PR DESCRIPTION
[According to our docs](https://customer.io/docs/transactional-api/#list-of-supported-parameters), `from`, `subject`, and `body` can be overridden, even when `transactional_message_id` is provided.

Previously, `subject` and `body` could only be overridden if `from` was also included.

closes #74