### PR TITLE
Use a version of https.request that only uses two arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+- Fix an issue with some instances of `HTTPS.request` in certain runtimes ([#83](https://github.com/customerio/customerio-node/pull/83))
+
 ## [3.0.2]
 
 - Fix a few issues in the README documentation ([#73](https://github.com/customerio/customerio-node/pull/73))

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A node client for the Customer.io [REST API](https://learn.customer.io/api/).
 
+## React Native and alternative Node runtimes
+
+This project is developed for and tested against the latest and LTS versions of Node.js. Many runtimes, such as React Native, often have subtle differences to the APIs and standard library offered by Node.js. These differences can cause issues when using this library with those runtimes.
+
+If you would like to use Customer.io with React Native or an alternate runtime, we recommend using our [Track](https://customer.io/docs/api/#tag/trackOverview) and [App](https://customer.io/docs/api/#tag/appOverview) APIs directly using the built-in HTTP client available in your runtime.
+
 ## Installation
 
 ```

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,5 +1,6 @@
 import { request } from 'https';
 import type { RequestOptions } from 'https';
+import { URL } from 'url';
 import { CustomerIORequestError } from './utils';
 
 export type BasicAuth = {
@@ -51,7 +52,7 @@ export default class CIORequest {
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
-      'Content-Length': body ? Buffer.byteLength(body,'utf8') : 0,
+      'Content-Length': body ? Buffer.byteLength(body, 'utf8') : 0,
     };
 
     return { method, uri, headers, body };
@@ -59,8 +60,14 @@ export default class CIORequest {
 
   handler({ uri, body, method, headers }: RequestHandlerOptions): Promise<Record<string, any>> {
     return new Promise((resolve, reject) => {
-      let options = Object.assign({}, this.defaults, { method, headers });
-      let req = request(uri, options, (res) => {
+      let url = new URL(uri);
+      let options = Object.assign<{}, RequestOptions, RequestOptions>({}, this.defaults, {
+        method,
+        headers,
+        hostname: url.hostname,
+        path: url.pathname,
+      });
+      let req = request(options, (res) => {
         let chunks: Buffer[] = [];
 
         res.on('data', (data: Buffer) => {


### PR DESCRIPTION
Closes #79

As mentioned in https://github.com/customerio/customerio-node/issues/79#issuecomment-908388485 some node runtimes don't support the newer (since `10.9.0`) signature of `https.request` which allows the `uri` to be provided separately from the `options` object. This is likely the root cause of #79, so this should fix this particular issue.