### PR TITLE
Use the latest Maintenance, LTS, Current, and old current versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "10", "14", "15"]
+        node: ["12", "14", "15", "16"]
     steps:
       - uses: actions/checkout@v2
       - name: setup node


### PR DESCRIPTION
This updates our tested versions of node to include the following from the official [Node release docs](https://nodejs.org/en/about/releases/)

- Maintenance LTS
- Current LTS
- Old current
- New current