### PR TITLE
Use trackRoot in mergeCustomers

### DIFF
--- a/lib/track.ts
+++ b/lib/track.ts
@@ -144,7 +144,7 @@ export class TrackClient {
       throw new MissingParamError('secondaryId');
     }
 
-    return this.request.post(`${this.apiRoot}/merge_customers`, {
+    return this.request.post(`${this.trackRoot}/merge_customers`, {
       primary: {
         [primaryIdType]: primaryId,
       },


### PR DESCRIPTION
`merge_customers` only exists on the Track api.