### PR TITLE
Set `User-Agent` for proper activity log sources in Customer.io

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,6 +1,8 @@
 import { request } from 'https';
 import type { RequestOptions } from 'https';
 import { URL } from 'url';
+import fs from 'fs';
+import { resolve } from 'path';
 import { CustomerIORequestError } from './utils';
 
 export type BasicAuth = {
@@ -20,6 +22,7 @@ export type RequestHandlerOptions = {
 };
 
 const TIMEOUT = 10_000;
+const PACKAGE_JSON = fs.readFileSync(resolve(__dirname, '..', 'package.json'));
 
 export default class CIORequest {
   apikey?: BasicAuth['apikey'];
@@ -49,10 +52,23 @@ export default class CIORequest {
 
   options(uri: string, method: RequestOptions['method'], data?: RequestData): RequestHandlerOptions {
     const body = data ? JSON.stringify(data) : null;
+    let libraryVersion = 'Unknown';
+
+    try {
+      let json = JSON.parse(PACKAGE_JSON.toString());
+
+      libraryVersion = json.version;
+    } catch {
+      console.warn(
+        'WARN: package.json contents could not be read. Activity source data in Customer.io will be incorrect.',
+      );
+    }
+
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
       'Content-Length': body ? Buffer.byteLength(body, 'utf8') : 0,
+      'User-Agent': `Customer.io Node Client/${libraryVersion}`,
     };
 
     return { method, uri, headers, body };

--- a/test/request-track-api.ts
+++ b/test/request-track-api.ts
@@ -1,7 +1,9 @@
 import avaTest, { TestInterface } from 'ava';
-import https, { RequestOptions } from 'https';
+import https from 'https';
 import sinon, { SinonStub } from 'sinon';
 import { PassThrough } from 'stream';
+import fs from 'fs';
+import { resolve } from 'path';
 import Request from '../lib/request';
 
 type TestContext = { req: Request; httpsReq: sinon.SinonStub };
@@ -14,12 +16,14 @@ const apikey = 'abc';
 const uri = 'https://track.customer.io/api/v1/customers/1';
 const data = { first_name: 'Bruce', last_name: 'Wayne' };
 const auth = `Basic ${Buffer.from(`${siteid}:${apikey}`).toString('base64')}`;
+const PACKAGE_VERSION = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString()).version;
 const baseOptions = {
   uri,
   headers: {
     Authorization: auth,
     'Content-Type': 'application/json',
     'Content-Length': 0,
+    'User-Agent': `Customer.io Node Client/${PACKAGE_VERSION}`,
   },
 };
 const putOptions = Object.assign({}, baseOptions, {
@@ -106,6 +110,26 @@ test('#options sets Content-Length using body length in bytes', (t) => {
   const resultOptions = t.context.req.options(uri, method, body);
 
   t.deepEqual(resultOptions, expectedOptions);
+});
+
+test('#options sets User-Agent even if package.json cannot be read', (t) => {
+  const jsonParseStub = sinon.stub(JSON, 'parse').throws();
+  const body = { bad_agent: true };
+  const method = 'POST';
+  const expectedOptions = {
+    ...baseOptions,
+    method,
+    headers: {
+      ...baseOptions.headers,
+      'Content-Length': 18,
+      'User-Agent': 'Customer.io Node Client/Unknown',
+    },
+    body: JSON.stringify(body),
+  };
+  const resultOptions = t.context.req.options(uri, method, body);
+
+  t.deepEqual(resultOptions, expectedOptions);
+  jsonParseStub.restore();
 });
 
 test('#handler returns a promise', (t) => {


### PR DESCRIPTION
In order for Customer.io to properly add source information to activity log entries in the app, we rely on the `User-Agent` header to be set in a specific format from our libraries. This matches the formatting of our [go](https://github.com/customerio/go-customerio/blob/main/customerio.go#L17), [ruby](https://github.com/customerio/customerio-ruby/blob/main/lib/customerio/base_client.rb#L47), and [python](https://github.com/customerio/customerio-python/blob/main/customerio/client_base.py#L23) libraries.