### PR TITLE
Revert "Set `User-Agent` for proper activity log sources in Customer.io"

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,8 +1,6 @@
 import { request } from 'https';
 import type { RequestOptions } from 'https';
 import { URL } from 'url';
-import fs from 'fs';
-import { resolve } from 'path';
 import { CustomerIORequestError } from './utils';
 
 export type BasicAuth = {
@@ -22,7 +20,6 @@ export type RequestHandlerOptions = {
 };
 
 const TIMEOUT = 10_000;
-const PACKAGE_JSON = fs.readFileSync(resolve(__dirname, '..', 'package.json'));
 
 export default class CIORequest {
   apikey?: BasicAuth['apikey'];
@@ -52,23 +49,10 @@ export default class CIORequest {
 
   options(uri: string, method: RequestOptions['method'], data?: RequestData): RequestHandlerOptions {
     const body = data ? JSON.stringify(data) : null;
-    let libraryVersion = 'Unknown';
-
-    try {
-      let json = JSON.parse(PACKAGE_JSON.toString());
-
-      libraryVersion = json.version;
-    } catch {
-      console.warn(
-        'WARN: package.json contents could not be read. Activity source data in Customer.io will be incorrect.',
-      );
-    }
-
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
       'Content-Length': body ? Buffer.byteLength(body, 'utf8') : 0,
-      'User-Agent': `Customer.io Node Client/${libraryVersion}`,
     };
 
     return { method, uri, headers, body };

--- a/test/request-track-api.ts
+++ b/test/request-track-api.ts
@@ -1,9 +1,7 @@
 import avaTest, { TestInterface } from 'ava';
-import https from 'https';
+import https, { RequestOptions } from 'https';
 import sinon, { SinonStub } from 'sinon';
 import { PassThrough } from 'stream';
-import fs from 'fs';
-import { resolve } from 'path';
 import Request from '../lib/request';
 
 type TestContext = { req: Request; httpsReq: sinon.SinonStub };
@@ -16,14 +14,12 @@ const apikey = 'abc';
 const uri = 'https://track.customer.io/api/v1/customers/1';
 const data = { first_name: 'Bruce', last_name: 'Wayne' };
 const auth = `Basic ${Buffer.from(`${siteid}:${apikey}`).toString('base64')}`;
-const PACKAGE_VERSION = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString()).version;
 const baseOptions = {
   uri,
   headers: {
     Authorization: auth,
     'Content-Type': 'application/json',
     'Content-Length': 0,
-    'User-Agent': `Customer.io Node Client/${PACKAGE_VERSION}`,
   },
 };
 const putOptions = Object.assign({}, baseOptions, {
@@ -110,26 +106,6 @@ test('#options sets Content-Length using body length in bytes', (t) => {
   const resultOptions = t.context.req.options(uri, method, body);
 
   t.deepEqual(resultOptions, expectedOptions);
-});
-
-test('#options sets User-Agent even if package.json cannot be read', (t) => {
-  const jsonParseStub = sinon.stub(JSON, 'parse').throws();
-  const body = { bad_agent: true };
-  const method = 'POST';
-  const expectedOptions = {
-    ...baseOptions,
-    method,
-    headers: {
-      ...baseOptions.headers,
-      'Content-Length': 18,
-      'User-Agent': 'Customer.io Node Client/Unknown',
-    },
-    body: JSON.stringify(body),
-  };
-  const resultOptions = t.context.req.options(uri, method, body);
-
-  t.deepEqual(resultOptions, expectedOptions);
-  jsonParseStub.restore();
 });
 
 test('#handler returns a promise', (t) => {


### PR DESCRIPTION
Reverts customerio/customerio-node#93

With #93 I introduced a bug where loading the package would immediately cause an unhandled error because of how the typescript files are compiled and published. It naively believes `package.json` will be in the parent folder, but it's not when build and published.

I'll fix this in a follow up PR with a more robust solution, but this will prevent more crashes when published.

```
Uncaught:
Error: ENOENT: no such file or directory, open '/home/mike/node_modules/customerio-node/dist/package.json'
    at Object.openSync (fs.js:462:3)
    at Object.readFileSync (fs.js:364:35)
    at Object.<anonymous> (/home/mike/node_modules/customerio-node/dist/lib/request.js:12:35)
    at Module._compile (internal/modules/cjs/loader.js:999:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1027:10)
    at Module.load (internal/modules/cjs/loader.js:863:32)
    at Function.Module._load (internal/modules/cjs/loader.js:708:14)
    at Module.require (internal/modules/cjs/loader.js:887:19)
    at require (internal/modules/cjs/helpers.js:74:18) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/home/mike/node_modules/customerio-node/dist/package.json'
}
```