### PR TITLE
Set `User-Agent` for proper activity log sources in Customer.io (again)

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -51,10 +51,23 @@ export default class CIORequest {
 
   options(uri: string, method: RequestOptions['method'], data?: RequestData): RequestHandlerOptions {
     const body = data ? JSON.stringify(data) : null;
+    let libraryVersion = 'Unknown';
+
+    try {
+      let json = JSON.parse(PACKAGE_JSON.toString());
+
+      libraryVersion = json.version;
+    } catch {
+      console.warn(
+        'WARN: package.json contents could not be read. Activity source data in Customer.io will be incorrect.',
+      );
+    }
+
     const headers = {
       Authorization: this.auth,
       'Content-Type': 'application/json',
       'Content-Length': body ? Buffer.byteLength(body, 'utf8') : 0,
+      'User-Agent': `Customer.io Node Client/${libraryVersion}`,
     };
 
     return { method, uri, headers, body };

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,7 +1,8 @@
 import { request } from 'https';
 import type { RequestOptions } from 'https';
 import { URL } from 'url';
-import { CustomerIORequestError } from './utils';
+import { resolve } from 'path';
+import { CustomerIORequestError, findPackageJson } from './utils';
 
 export type BasicAuth = {
   apikey: string;
@@ -20,6 +21,7 @@ export type RequestHandlerOptions = {
 };
 
 const TIMEOUT = 10_000;
+const PACKAGE_JSON = findPackageJson(resolve(__dirname, '..'));
 
 export default class CIORequest {
   apikey?: BasicAuth['apikey'];

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage } from 'http';
 import { resolve } from 'path';
-import { statSync, readFileSync } from 'fs';
+import fs, { statSync, readFileSync } from 'fs';
 
 export const isEmpty = (value: unknown) => {
   return value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
@@ -41,15 +41,15 @@ ${json.meta.errors.map((error: string) => `  - ${error}`).join('\n')}`;
 export const findPackageJson = (dirName: string): string => {
   const path = resolve(dirName, 'package.json');
 
-  if (statSync(path, { throwIfNoEntry: false }) == null) {
+  if (fs.statSync(path, { throwIfNoEntry: false }) == null) {
     const parentPath = resolve(dirName, '..');
 
-    if (statSync(parentPath, { throwIfNoEntry: false }) != null) {
+    if (fs.statSync(parentPath, { throwIfNoEntry: false }) != null) {
       return findPackageJson(parentPath);
     }
 
     return '';
   }
 
-  return readFileSync(path).toString();
+  return fs.readFileSync(path).toString();
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,6 @@
 import { IncomingMessage } from 'http';
+import { resolve } from 'path';
+import { statSync, readFileSync } from 'fs';
 
 export const isEmpty = (value: unknown) => {
   return value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
@@ -35,3 +37,19 @@ ${json.meta.errors.map((error: string) => `  - ${error}`).join('\n')}`;
     this.body = body;
   }
 }
+
+export const findPackageJson = (dirName: string): string => {
+  const path = resolve(dirName, 'package.json');
+
+  if (statSync(path, { throwIfNoEntry: false }) == null) {
+    const parentPath = resolve(dirName, '..');
+
+    if (statSync(parentPath, { throwIfNoEntry: false }) != null) {
+      return findPackageJson(parentPath);
+    }
+
+    return '';
+  }
+
+  return readFileSync(path).toString();
+};

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -39,9 +39,10 @@ ${json.meta.errors.map((error: string) => `  - ${error}`).join('\n')}`;
 }
 
 // Node.js v12 doesn't support the `throwIfNoEntry`
+// Once we drop v12, let's remove this function and use `throwIfNoEntry`
 const checkIfPathExists = (path: string) => {
   try {
-    let stat = fs.statSync(path, { throwIfNoEntry: false });
+    let stat = fs.statSync(path);
 
     return stat;
   } catch {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage } from 'http';
 import { resolve } from 'path';
-import fs, { statSync, readFileSync } from 'fs';
+import fs from 'fs';
 
 export const isEmpty = (value: unknown) => {
   return value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
@@ -38,13 +38,24 @@ ${json.meta.errors.map((error: string) => `  - ${error}`).join('\n')}`;
   }
 }
 
+// Node.js v12 doesn't support the `throwIfNoEntry`
+const checkIfPathExists = (path: string) => {
+  try {
+    let stat = fs.statSync(path, { throwIfNoEntry: false });
+
+    return stat;
+  } catch {
+    return undefined;
+  }
+};
+
 export const findPackageJson = (dirName: string): string => {
   const path = resolve(dirName, 'package.json');
 
-  if (fs.statSync(path, { throwIfNoEntry: false }) == null) {
+  if (checkIfPathExists(path) == null) {
     const parentPath = resolve(dirName, '..');
 
-    if (fs.statSync(parentPath, { throwIfNoEntry: false }) != null) {
+    if (checkIfPathExists(parentPath) != null) {
       return findPackageJson(parentPath);
     }
 

--- a/test/request-track-api.ts
+++ b/test/request-track-api.ts
@@ -1,7 +1,9 @@
 import avaTest, { TestInterface } from 'ava';
-import https, { RequestOptions } from 'https';
+import https from 'https';
 import sinon, { SinonStub } from 'sinon';
 import { PassThrough } from 'stream';
+import { resolve } from 'path';
+import fs from 'fs';
 import Request from '../lib/request';
 
 type TestContext = { req: Request; httpsReq: sinon.SinonStub };
@@ -14,12 +16,14 @@ const apikey = 'abc';
 const uri = 'https://track.customer.io/api/v1/customers/1';
 const data = { first_name: 'Bruce', last_name: 'Wayne' };
 const auth = `Basic ${Buffer.from(`${siteid}:${apikey}`).toString('base64')}`;
+const PACKAGE_VERSION = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString()).version;
 const baseOptions = {
   uri,
   headers: {
     Authorization: auth,
     'Content-Type': 'application/json',
     'Content-Length': 0,
+    'User-Agent': `Customer.io Node Client/${PACKAGE_VERSION}`,
   },
 };
 const putOptions = Object.assign({}, baseOptions, {
@@ -106,6 +110,26 @@ test('#options sets Content-Length using body length in bytes', (t) => {
   const resultOptions = t.context.req.options(uri, method, body);
 
   t.deepEqual(resultOptions, expectedOptions);
+});
+
+test('#options sets User-Agent even if package.json cannot be read', (t) => {
+  const jsonParseStub = sinon.stub(JSON, 'parse').throws();
+  const body = { bad_agent: true };
+  const method = 'POST';
+  const expectedOptions = {
+    ...baseOptions,
+    method,
+    headers: {
+      ...baseOptions.headers,
+      'Content-Length': 18,
+      'User-Agent': 'Customer.io Node Client/Unknown',
+    },
+    body: JSON.stringify(body),
+  };
+  const resultOptions = t.context.req.options(uri, method, body);
+
+  t.deepEqual(resultOptions, expectedOptions);
+  jsonParseStub.restore();
 });
 
 test('#handler returns a promise', (t) => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -6,7 +6,7 @@ import { findPackageJson } from '../lib/utils';
 
 const PACKAGE_JSON = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString());
 
-test('#findPackageJson walks the tree to find package.json', (t) => {
+test.serial('#findPackageJson walks the tree to find package.json', (t) => {
   const sandbox = sinon.createSandbox();
   const statSpy = sandbox.spy(fs, 'statSync');
   const readSpy = sandbox.spy(fs, 'readFileSync');
@@ -36,7 +36,7 @@ test('#findPackageJson walks the tree to find package.json', (t) => {
   readSpy.restore();
 });
 
-test('#findPackageJson returns a default if no package.json is found', (t) => {
+test.serial('#findPackageJson returns a default if no package.json is found', (t) => {
   const sandbox = sinon.createSandbox();
   const statStub = sandbox.stub(fs, 'statSync').returns(undefined);
   const readSpy = sandbox.spy(fs, 'readFileSync');

--- a/test/util.ts
+++ b/test/util.ts
@@ -18,17 +18,13 @@ test.serial('#findPackageJson walks the tree to find package.json', (t) => {
   t.is(statSpy.callCount, 3, 'statSync called three times');
   t.deepEqual(
     statSpy.getCall(0).args,
-    [resolve(__dirname, 'package.json'), { throwIfNoEntry: false }],
+    [resolve(__dirname, 'package.json')],
     'called with the correct arguments initially',
   );
-  t.deepEqual(
-    statSpy.getCall(1).args,
-    [resolve(__dirname, '..'), { throwIfNoEntry: false }],
-    'checks if parent directory exists',
-  );
+  t.deepEqual(statSpy.getCall(1).args, [resolve(__dirname, '..')], 'checks if parent directory exists');
   t.deepEqual(
     statSpy.getCall(2).args,
-    [resolve(__dirname, '..', 'package.json'), { throwIfNoEntry: false }],
+    [resolve(__dirname, '..', 'package.json')],
     'checks if package.json in parent directory exists',
   );
 
@@ -38,7 +34,7 @@ test.serial('#findPackageJson walks the tree to find package.json', (t) => {
 
 test.serial('#findPackageJson returns a default if no package.json is found', (t) => {
   const sandbox = sinon.createSandbox();
-  const statStub = sandbox.stub(fs, 'statSync').returns(undefined);
+  const statStub = sandbox.stub(fs, 'statSync').throws();
   const readSpy = sandbox.spy(fs, 'readFileSync');
 
   let json = findPackageJson(__dirname);
@@ -47,14 +43,10 @@ test.serial('#findPackageJson returns a default if no package.json is found', (t
   t.is(statStub.callCount, 2, 'statSync called two times');
   t.deepEqual(
     statStub.getCall(0).args,
-    [resolve(__dirname, 'package.json'), { throwIfNoEntry: false }],
+    [resolve(__dirname, 'package.json')],
     'called with the correct arguments initially',
   );
-  t.deepEqual(
-    statStub.getCall(1).args,
-    [resolve(__dirname, '..'), { throwIfNoEntry: false }],
-    'checks if parent directory exists',
-  );
+  t.deepEqual(statStub.getCall(1).args, [resolve(__dirname, '..')], 'checks if parent directory exists');
 
   statStub.restore();
   readSpy.restore();

--- a/test/util.ts
+++ b/test/util.ts
@@ -7,8 +7,9 @@ import { findPackageJson } from '../lib/utils';
 const PACKAGE_JSON = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString());
 
 test('#findPackageJson walks the tree to find package.json', (t) => {
-  const statSpy = sinon.spy(fs, 'statSync');
-  const readSpy = sinon.spy(fs, 'readFileSync');
+  const sandbox = sinon.createSandbox();
+  const statSpy = sandbox.spy(fs, 'statSync');
+  const readSpy = sandbox.spy(fs, 'readFileSync');
 
   // No package.json in the test directory
   let json = findPackageJson(__dirname);
@@ -36,8 +37,9 @@ test('#findPackageJson walks the tree to find package.json', (t) => {
 });
 
 test('#findPackageJson returns a default if no package.json is found', (t) => {
-  const statStub = sinon.stub(fs, 'statSync').returns(undefined);
-  const readSpy = sinon.spy(fs, 'readFileSync');
+  const sandbox = sinon.createSandbox();
+  const statStub = sandbox.stub(fs, 'statSync').returns(undefined);
+  const readSpy = sandbox.spy(fs, 'readFileSync');
 
   let json = findPackageJson(__dirname);
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,0 +1,59 @@
+import test from 'ava';
+import sinon from 'sinon';
+import fs from 'fs';
+import { resolve } from 'path';
+import { findPackageJson } from '../lib/utils';
+
+const PACKAGE_JSON = JSON.parse(fs.readFileSync(resolve(__dirname, '..', 'package.json')).toString());
+
+test('#findPackageJson walks the tree to find package.json', (t) => {
+  const statSpy = sinon.spy(fs, 'statSync');
+  const readSpy = sinon.spy(fs, 'readFileSync');
+
+  // No package.json in the test directory
+  let json = findPackageJson(__dirname);
+
+  t.deepEqual(JSON.parse(json), PACKAGE_JSON, 'returns the correct package.json');
+  t.is(statSpy.callCount, 3, 'statSync called three times');
+  t.deepEqual(
+    statSpy.getCall(0).args,
+    [resolve(__dirname, 'package.json'), { throwIfNoEntry: false }],
+    'called with the correct arguments initially',
+  );
+  t.deepEqual(
+    statSpy.getCall(1).args,
+    [resolve(__dirname, '..'), { throwIfNoEntry: false }],
+    'checks if parent directory exists',
+  );
+  t.deepEqual(
+    statSpy.getCall(2).args,
+    [resolve(__dirname, '..', 'package.json'), { throwIfNoEntry: false }],
+    'checks if package.json in parent directory exists',
+  );
+
+  statSpy.restore();
+  readSpy.restore();
+});
+
+test('#findPackageJson returns a default if no package.json is found', (t) => {
+  const statStub = sinon.stub(fs, 'statSync').returns(undefined);
+  const readSpy = sinon.spy(fs, 'readFileSync');
+
+  let json = findPackageJson(__dirname);
+
+  t.is(json, '', 'returns an empty string');
+  t.is(statStub.callCount, 2, 'statSync called two times');
+  t.deepEqual(
+    statStub.getCall(0).args,
+    [resolve(__dirname, 'package.json'), { throwIfNoEntry: false }],
+    'called with the correct arguments initially',
+  );
+  t.deepEqual(
+    statStub.getCall(1).args,
+    [resolve(__dirname, '..'), { throwIfNoEntry: false }],
+    'checks if parent directory exists',
+  );
+
+  statStub.restore();
+  readSpy.restore();
+});


### PR DESCRIPTION
This re-implements #93 and essentially reverts #95.

In order for Customer.io to properly add source information to activity log entries in the app, we rely on the `User-Agent` header to be set in a specific format from our libraries. This matches the formatting of our [go](https://github.com/customerio/go-customerio/blob/main/customerio.go#L17), [ruby](https://github.com/customerio/customerio-ruby/blob/main/lib/customerio/base_client.rb#L47), and [python](https://github.com/customerio/customerio-python/blob/main/customerio/client_base.py#L23) libraries.

The difference here is that we walk the directory path recursively to find the package.json. If one isn't found, we gracefully fall back to `Unknown`.