### PR TITLE
feat: add support for invite-type anonymous event tracking

### DIFF
--- a/lib/track.ts
+++ b/lib/track.ts
@@ -79,8 +79,10 @@ export class TrackClient {
     let payload = { ...data};
 
     if (!isEmpty(anonymousId)) {
-      payload["anonymousId"] = anonymousId;
+      payload["anonymous_id"] = anonymousId;
     }
+
+    console.log(payload);
 
     return this.request.post(`${this.trackRoot}/events`, payload);
   }

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -82,8 +82,6 @@ export class TrackClient {
       payload["anonymous_id"] = anonymousId;
     }
 
-    console.log(payload);
-
     return this.request.post(`${this.trackRoot}/events`, payload);
   }
 

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -72,15 +72,17 @@ export class TrackClient {
   }
 
   trackAnonymous(anonymousId: string | number, data: RequestData = {}) {
-    if (isEmpty(anonymousId)) {
-      throw new MissingParamError('anonymousId');
-    }
-
     if (isEmpty(data.name)) {
       throw new MissingParamError('data.name');
     }
 
-    return this.request.post(`${this.trackRoot}/events`, { ...data, anonymous_id: anonymousId });
+    let payload = { ...data};
+
+    if (!isEmpty(anonymousId)) {
+      payload["anonymousId"] = anonymousId;
+    }
+
+    return this.request.post(`${this.trackRoot}/events`, payload);
   }
 
   trackPageView(customerId: string | number, path: string) {

--- a/test/track.ts
+++ b/test/track.ts
@@ -119,13 +119,25 @@ ID_INPUTS.forEach(([input, expected]) => {
 
 test('#trackAnonymous works', (t) => {
   sinon.stub(t.context.client.request, 'post');
-  t.throws(() => t.context.client.trackAnonymous(''), { message: 'anonymousId is required' });
+  t.throws(() => t.context.client.trackAnonymous(''), { message: 'data.name is required' });
   t.throws(() => t.context.client.trackAnonymous('123'), { message: 'data.name is required' });
   t.throws(() => t.context.client.trackAnonymous('123', { data: {} }), { message: 'data.name is required' });
   t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
       anonymous_id: '123',
+      name: 'purchase',
+      data: 'yep',
+    }),
+  );
+});
+
+test('#trackAnonymous ignores blank anonymousId', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.trackAnonymous('', { name: 'purchase', data: 'yep' })
+  t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
       name: 'purchase',
       data: 'yep',
     }),

--- a/test/track.ts
+++ b/test/track.ts
@@ -135,7 +135,6 @@ test('#trackAnonymous works', (t) => {
 test('#trackAnonymous ignores blank anonymousId', (t) => {
   sinon.stub(t.context.client.request, 'post');
   t.context.client.trackAnonymous('', { name: 'purchase', data: 'yep' })
-  t.context.client.trackAnonymous('123', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
       name: 'purchase',


### PR DESCRIPTION
Re-introduces support for anonymous event tracking using activity items unassociated with profiles by passing in a blank value for `anonymous_id`

**Usage:**

```node
trackAnonymous("", {
  name: "my-event",
  data: {
    foo: "bar",
  },
})
```