### PR TITLE
Added CustomerIORequestError as an export for this package

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/track';
 export * from './lib/api';
 export * from './lib/regions';
+export { CustomerIORequestError } from './lib/utils';


### PR DESCRIPTION
We needed to handle errors and were importing the type from `customerio-node/dist/lib/utils` which doesn't feel right, so i have added an export in `index.ts` for this type.