### PR TITLE
Prepare 3.3.2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,9 @@ yarn.lock
 .nyc_output
 .github
 .prettierrc.js
+.prettierignore
+.gitpod.yml
+.husky
+tsconfig.json
+update-version.js
+check-version.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Add more files to the npm ignore file
+- Add more files to the npm ignore file ([#109](https://github.com/customerio/customerio-node/pull/109))
 - Attempt to re-publish to get a proper build before publishing
 
 ## [3.3.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [3.3.2]
+
+### Changed
+
+- Add more files to the npm ignore file
+- Attempt to re-publish to get a proper build before publishing
+
 ## [3.3.1]
 
 ### Changed

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '3.3.1';
+export const version = '3.3.2';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "customerio-node",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
This updates the npmignore file and also bumps the version to attempt a republish after [3.3.1 somehow failed](https://github.com/customerio/customerio-node/pull/108#issuecomment-1118512282).