### PR TITLE
Drop node v12 support, add node v18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["12", "14", "15", "16"]
+        node: ["14", "15", "16", "18"]
     steps:
       - uses: actions/checkout@v2
       - name: setup node

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: ["14", "15", "16", "18"]
+        node: ["14", "15", "16", "17", "18"]
     steps:
       - uses: actions/checkout@v2
       - name: setup node


### PR DESCRIPTION
This drops support for node v12 from our CI runs, and adds v18 which was released in April 2022. This matches the current node LTS schedule

![image](https://user-images.githubusercontent.com/464447/169264891-8b27c7d0-9413-4320-a23f-baca9647f020.png)
