### PR TITLE
chore: clarify diff between destroy and suppress

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ cio.destroy(1);
 
 - **id**: String or number (required)
 
+#### Attention! 
+
+This method will only delete a person and not suppress them. This means they can be readded. 
+If you need to suppress a person, please use [`cio.suppress`](https://github.com/customerio/customerio-node#ciosuppressid).
+
 ---
 
 ### Merge Customers


### PR DESCRIPTION
We had a ticket investigated because persons seemed like they weren't suppressed. The wrong method was called. Adding a link in the `cio.destroy` section to `cio.suppress` for clarity.