### PR TITLE
Use trackRoot instead of apiRoot for mergeCustomers

### DIFF
--- a/lib/track.ts
+++ b/lib/track.ts
@@ -150,7 +150,7 @@ export class TrackClient {
       throw new MissingParamError('secondaryId');
     }
 
-    return this.request.post(`${this.apiRoot}/merge_customers`, {
+    return this.request.post(`${this.trackRoot}/merge_customers`, {
       primary: {
         [primaryIdType]: primaryId,
       },

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -4,7 +4,7 @@ import { Region, RegionUS } from './regions';
 import { isEmpty } from './utils';
 import { IdentifierType } from './types';
 
-type TrackDefaults = RequestOptions & { region: Region; url?: string; apiUrl?: string };
+type TrackDefaults = RequestOptions & { region: Region; url?: string };
 
 class MissingParamError extends Error {
   constructor(param: string) {
@@ -19,7 +19,6 @@ export class TrackClient {
   defaults: TrackDefaults;
   request: Request;
   trackRoot: string;
-  apiRoot: string;
 
   constructor(siteid: BasicAuth['siteid'], apikey: BasicAuth['apikey'], defaults: Partial<TrackDefaults> = {}) {
     if (defaults.region && !(defaults.region instanceof Region)) {
@@ -32,7 +31,6 @@ export class TrackClient {
     this.request = new Request({ siteid: this.siteid, apikey: this.apikey }, this.defaults);
 
     this.trackRoot = this.defaults.url ? this.defaults.url : this.defaults.region.trackUrl;
-    this.apiRoot = this.defaults.apiUrl ? this.defaults.apiUrl : this.defaults.region.apiUrl;
   }
 
   identify(customerId: string | number, data: RequestData = {}) {

--- a/test/track.ts
+++ b/test/track.ts
@@ -23,7 +23,6 @@ test('constructor sets necessary variables', (t) => {
   t.is(t.context.client.siteid, '123');
   t.is(t.context.client.apikey, 'abc');
   t.is(t.context.client.trackRoot, RegionUS.trackUrl);
-  t.is(t.context.client.apiRoot, RegionUS.apiUrl);
 
   t.truthy(t.context.client.request);
   t.is(t.context.client.request.siteid, '123');
@@ -37,7 +36,6 @@ test('constructor sets correct URL for different regions', (t) => {
     t.is(client.siteid, '123');
     t.is(client.apikey, 'abc');
     t.is(client.trackRoot, region.trackUrl);
-    t.is(client.apiRoot, region.apiUrl);
 
     t.truthy(client.request);
     t.is(client.request.siteid, '123');
@@ -46,12 +44,11 @@ test('constructor sets correct URL for different regions', (t) => {
 });
 
 test('constructor sets correct URL for custom URLs', (t) => {
-  let client = new TrackClient('123', 'abc', { url: 'https://example.com/url', apiUrl: 'https://example.com/apiUrl' });
+  let client = new TrackClient('123', 'abc', { url: 'https://example.com/url' });
 
   t.is(client.siteid, '123');
   t.is(client.apikey, 'abc');
   t.is(client.trackRoot, 'https://example.com/url');
-  t.is(client.apiRoot, 'https://example.com/apiUrl');
 
   t.truthy(client.request);
   t.is(client.request.siteid, '123');
@@ -266,7 +263,7 @@ test('#mergeCustomers works', (t) => {
   ].forEach(([pTypeString, pId, sTypeString, sId]) => {
     t.context.client.mergeCustomers(pTypeString as IdentifierType, pId, sTypeString as IdentifierType, sId);
     t.truthy(
-      (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/merge_customers`, {
+      (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/merge_customers`, {
         primary: {
           [pTypeString]: pId,
         },

--- a/test/track.ts
+++ b/test/track.ts
@@ -43,7 +43,7 @@ test('constructor sets correct URL for different regions', (t) => {
   });
 });
 
-test('constructor sets correct URL for custom URLs', (t) => {
+test('constructor sets correct URL for custom URL', (t) => {
   let client = new TrackClient('123', 'abc', { url: 'https://example.com/url' });
 
   t.is(client.siteid, '123');


### PR DESCRIPTION
The mergeCustomers API call uses the wrong endpoint. This PR fixes it.

Also, the track API does not use the apiRoot/apiUrl variable, so I removed it

There is already another open PR but it is stale: https://github.com/customerio/customerio-node/pull/88