### PR TITLE
Add extra device data to attributes object in `addDevice`

### DIFF
--- a/lib/track.ts
+++ b/lib/track.ts
@@ -118,7 +118,12 @@ export class TrackClient {
     let { last_used, ...attributes } = data;
 
     return this.request.put(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/devices`, {
-      device: { id: device_id, platform, last_used, attributes },
+      device: {
+        id: device_id,
+        platform,
+        ...(last_used && { last_used }),
+        ...(Object.keys(attributes).length && { attributes }),
+      },
     });
   }
 

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -116,7 +116,7 @@ export class TrackClient {
     }
 
     return this.request.put(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/devices`, {
-      device: { id: device_id, platform, ...data },
+      device: { id: device_id, platform, attributes: { ...data } },
     });
   }
 

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -102,7 +102,7 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/push/events`, data);
   }
 
-  addDevice(customerId: string | number, device_id: string, platform: string, data = {}) {
+  addDevice(customerId: string | number, device_id: string, platform: string, data: Record<string, any> = {}) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
     }
@@ -115,8 +115,10 @@ export class TrackClient {
       throw new MissingParamError('platform');
     }
 
+    let { last_used, ...attributes } = data;
+
     return this.request.put(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/devices`, {
-      device: { id: device_id, platform, attributes: { ...data } },
+      device: { id: device_id, platform, last_used, attributes },
     });
   }
 

--- a/test/track.ts
+++ b/test/track.ts
@@ -191,12 +191,13 @@ ID_INPUTS.forEach(([input, expected]) => {
       message: 'platform is required',
     });
 
-    t.context.client.addDevice(input, '123', 'ios', { primary: true });
+    t.context.client.addDevice(input, '123', 'ios', { primary: true, last_used: 1613063089 });
     t.truthy(
       (t.context.client.request.put as SinonStub).calledWith(`${RegionUS.trackUrl}/customers/${expected}/devices`, {
         device: {
           id: '123',
           platform: 'ios',
+          last_used: 1613063089,
           attributes: {
             primary: true,
           },

--- a/test/track.ts
+++ b/test/track.ts
@@ -131,15 +131,15 @@ test('#trackAnonymous works', (t) => {
 
 test('#trackAnonymous ignores blank anonymousId', (t) => {
   sinon.stub(t.context.client.request, 'post');
-  t.context.client.trackAnonymous('', { name: 'purchase', data: 'yep' })
+  t.context.client.trackAnonymous('', { name: 'purchase', data: 'yep' });
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/events`, {
       name: 'purchase',
       data: 'yep',
     }),
-    );
-  });
-  
+  );
+});
+
 test('#trackPush works', (t) => {
   sinon.stub(t.context.client.request, 'post');
   t.context.client.trackPush();
@@ -197,7 +197,9 @@ ID_INPUTS.forEach(([input, expected]) => {
         device: {
           id: '123',
           platform: 'ios',
-          primary: true,
+          attributes: {
+            primary: true,
+          },
         },
       }),
     );


### PR DESCRIPTION
To add extra data to a device, we should use the `attributes` param in the add/update device API call ([see the official docs](https://www.customer.io/docs/api/#operation/add_device))

Currently, extra data gets spread out over the request params and it doesn't arrive in customer.io.

This PR makes sure that data that's passed along through the `data` param in the `addDevice` function, is properly sent to the API by putting it in the required `attributes` param.