### PR TITLE
Use `prepublishOnly` over `prepublish` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "scripts": {
     "test": "nyc ava",
     "build": "tsc -p tsconfig.json",
-    "prepublish": "npm run build",
+    "prepublishOnly": "npm run build",
     "prepare": "husky install",
     "version": "node update-version.js"
   }


### PR DESCRIPTION
Fixes https://github.com/customerio/customerio-node/pull/115#issuecomment-1249281430

Apparently, between npm 6 and 8, the `prepublish` script was deprecated in favor of `prepack`, `prepare`, or `prepublishOnly`. You can read more on the [npm 8 docs](https://docs.npmjs.com/cli/v8/using-npm/scripts#life-cycle-scripts). Since it's deprecated, it wasn't running on publish, causing me to publish a few versions that didn't have the correctly compiled code.

Since we only need to do this before publishing, I'm opting for `prepublishOnly`.

**Output before**
```shell
λ rm -rf dist; npm publish --dry-run
npm notice
npm notice 📦  customerio-node@3.3.6
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 11.7kB README.md
npm notice 427B   check-version.ts
npm notice 141B   index.ts
npm notice 2.6kB  lib/api.ts
npm notice 2.6kB  lib/api/requests.ts
npm notice 402B   lib/regions.ts
npm notice 3.4kB  lib/request.ts
npm notice 4.8kB  lib/track.ts
npm notice 83B    lib/types.ts
npm notice 1.1kB  lib/utils.ts
npm notice 32B    lib/version.ts
npm notice 1.7kB  package.json
npm notice === Tarball Details ===
npm notice name:          customerio-node
npm notice version:       3.3.6
npm notice filename:      customerio-node-3.3.6.tgz
npm notice package size:  9.6 kB
npm notice unpacked size: 30.0 kB
npm notice shasum:        abfabae66f38655ebc61d50499251cbae0a29833
npm notice integrity:     sha512-8fWHrJt7noHna[...]maSmFxQKKx/eg==
npm notice total files:   13
npm notice
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ customerio-node@3.3.6
```

**Output after**
```shell
λ rm -rf dist;npm publish --dry-run

> customerio-node@3.3.6 prepublishOnly
> npm run build


> customerio-node@3.3.6 build
> tsc -p tsconfig.json

npm notice
npm notice 📦  customerio-node@3.3.6
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 11.7kB README.md
npm notice 427B   check-version.ts
npm notice 141B   dist/index.d.ts
npm notice 1.1kB  dist/index.js
npm notice 797B   dist/lib/api.d.ts
npm notice 2.6kB  dist/lib/api.js
npm notice 1.4kB  dist/lib/api/requests.d.ts
npm notice 1.8kB  dist/lib/api/requests.js
npm notice 221B   dist/lib/regions.d.ts
npm notice 488B   dist/lib/regions.js
npm notice 1.3kB  dist/lib/request.d.ts
npm notice 3.1kB  dist/lib/request.js
npm notice 1.6kB  dist/lib/track.d.ts
npm notice 5.5kB  dist/lib/track.js
npm notice 96B    dist/lib/types.d.ts
npm notice 349B   dist/lib/types.js
npm notice 446B   dist/lib/utils.d.ts
npm notice 1.1kB  dist/lib/utils.js
npm notice 40B    dist/lib/version.d.ts
npm notice 130B   dist/lib/version.js
npm notice 141B   index.ts
npm notice 2.6kB  lib/api.ts
npm notice 2.6kB  lib/api/requests.ts
npm notice 402B   lib/regions.ts
npm notice 3.4kB  lib/request.ts
npm notice 4.8kB  lib/track.ts
npm notice 83B    lib/types.ts
npm notice 1.1kB  lib/utils.ts
npm notice 32B    lib/version.ts
npm notice 1.7kB  package.json
npm notice === Tarball Details ===
npm notice name:          customerio-node
npm notice version:       3.3.6
npm notice filename:      customerio-node-3.3.6.tgz
npm notice package size:  14.1 kB
npm notice unpacked size: 52.3 kB
npm notice shasum:        35f8f2aaca5f6272f292942fdc5d31b89ffd0474
npm notice integrity:     sha512-eFHn0abThqhRt[...]99GC2JSK0eOlg==
npm notice total files:   31
npm notice
npm notice Publishing to https://registry.npmjs.org/ (dry-run)
+ customerio-node@3.3.6
```