### PR TITLE
Transactional - amp_body prop to body_amp for consistency

### DIFF
--- a/examples/transactional-email.js
+++ b/examples/transactional-email.js
@@ -34,8 +34,8 @@ let req = new SendEmailRequest({
   bcc: '',
   subject: '',
   body: '',
-  plaintext_body: '',
-  amp_body: '',
+  body_plaintext: '',
+  body_amp: '',
   fake_bcc: false,
 
   disable_message_retention: false,

--- a/examples/transactional-email.js
+++ b/examples/transactional-email.js
@@ -34,7 +34,7 @@ let req = new SendEmailRequest({
   bcc: '',
   subject: '',
   body: '',
-  body_plaintext: '',
+  body_plain: '',
   body_amp: '',
   fake_bcc: false,
 

--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -11,7 +11,7 @@ export type SendEmailRequestOptionalOptions = Partial<{
   preheader: string;
   reply_to: string;
   bcc: string;
-  body_plaintext: string;
+  body_plain: string;
   body_amp: string;
   fake_bcc: boolean;
   disable_message_retention: boolean;
@@ -53,7 +53,7 @@ export class SendEmailRequest {
       preheader: opts.preheader,
       reply_to: opts.reply_to,
       bcc: opts.bcc,
-      body_plaintext: opts.body_plaintext,
+      body_plain: opts.body_plain,
       body_amp: opts.body_amp,
       fake_bcc: opts.fake_bcc,
       disable_message_retention: opts.disable_message_retention,

--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -11,8 +11,8 @@ export type SendEmailRequestOptionalOptions = Partial<{
   preheader: string;
   reply_to: string;
   bcc: string;
-  plaintext_body: string;
-  amp_body: string;
+  body_plaintext: string;
+  body_amp: string;
   fake_bcc: boolean;
   disable_message_retention: boolean;
   send_to_unsubscribed: boolean;
@@ -53,8 +53,8 @@ export class SendEmailRequest {
       preheader: opts.preheader,
       reply_to: opts.reply_to,
       bcc: opts.bcc,
-      plaintext_body: opts.plaintext_body,
-      amp_body: opts.amp_body,
+      body_plaintext: opts.body_plaintext,
+      body_amp: opts.body_amp,
       fake_bcc: opts.fake_bcc,
       disable_message_retention: opts.disable_message_retention,
       send_to_unsubscribed: opts.send_to_unsubscribed,


### PR DESCRIPTION
Updating Transactional API endpoint properties `amp_body` `amp_plaintext` to `body_amp` `body_plaintext` to maintain consistency with Newsletters API.