### PR TITLE
feat: add report metrics endpoint

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -25,6 +25,55 @@ export interface PushRequestData {
   event?: 'delivered' | 'opened' | 'converted';
   timestamp?: number;
 }
+export interface ReportEmailMetricsRequestData {
+  delivery_id: string;
+  metric: 'bounced' | 'clicked' | 'converted' | 'deferred' | 'delivered' | 'dropped' | 'opened' | 'spammed';
+  timestamp?: number;
+  recipient?: string;
+  reason?: string;
+  href?: string;
+}
+export interface ReportInappMetricsRequestData {
+  delivery_id: string;
+  metric: 'clicked' | 'converted' | 'opened';
+  timestamp?: number;
+  recipient?: string;
+  href?: string;
+}
+export interface ReportPushMetricsRequestData {
+  delivery_id: string;
+  metric: 'converted' | 'delivered' | 'opened';
+  timestamp?: number;
+  recipient?: string;
+}
+export interface ReportSlackMetricsRequestData {
+  delivery_id: string;
+  metric: 'clicked' | 'converted' | 'delivered' | 'opened';
+  timestamp?: number;
+  href?: string;
+}
+export interface ReportSMSMetricsRequestData {
+  delivery_id: string;
+  metric: 'bounced' | 'clicked' | 'delivered' | 'opened';
+  timestamp?: number;
+  recipient?: string;
+  reason?: string;
+  href?: string;
+}
+export interface ReportWebhookMetricsRequestData {
+  delivery_id: string;
+  metric: 'bounced' | 'clicked' | 'converted' | 'deferred' | 'delivered' | 'dropped' | 'opened' | 'spammed';
+  timestamp?: number;
+  reason?: string;
+  href?: string;
+}
+export type ReportMetricsRequestData =
+  | ReportEmailMetricsRequestData
+  | ReportInappMetricsRequestData
+  | ReportPushMetricsRequestData
+  | ReportSlackMetricsRequestData
+  | ReportSMSMetricsRequestData
+  | ReportWebhookMetricsRequestData;
 
 const TIMEOUT = 10_000;
 

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -1,5 +1,5 @@
 import type { RequestOptions } from 'https';
-import Request, { BasicAuth, RequestData, PushRequestData } from './request';
+import Request, { BasicAuth, RequestData, PushRequestData, ReportMetricsRequestData } from './request';
 import { Region, RegionUS } from './regions';
 import { isEmpty, isIdentifierType, MissingParamError } from './utils';
 import { IdentifierType } from './types';
@@ -99,6 +99,13 @@ export class TrackClient {
     });
   }
 
+  reportMetrics(data: ReportMetricsRequestData) {
+    return this.request.post(`${this.trackRoot}/metrics`, data);
+  }
+
+  /**
+   * @deprecated Use reportMetrics instead
+   */
   trackPush(data: PushRequestData = {}) {
     return this.request.post(`${this.trackRoot}/push/events`, data);
   }

--- a/test/track.ts
+++ b/test/track.ts
@@ -173,6 +173,37 @@ test('#trackPush works', (t) => {
   );
 });
 
+test('#reportMetrics works', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.reportMetrics({
+    delivery_id: 'RPILAgUBcRhIBqSfeiIwdIYJKxTY',
+    metric: 'opened',
+  });
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/metrics`, {
+      delivery_id: 'RPILAgUBcRhIBqSfeiIwdIYJKxTY',
+      metric: 'opened',
+    }),
+  );
+
+  t.context.client.reportMetrics({
+    delivery_id: 'RPILAgUBcRhIBqSfeiIwdIYJKxTY',
+    metric: 'clicked',
+    timestamp: 1613063089,
+    recipient: 'cool.person@company.com',
+    href: 'https://example.com',
+  });
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.trackUrl}/metrics`, {
+      delivery_id: 'RPILAgUBcRhIBqSfeiIwdIYJKxTY',
+      metric: 'clicked',
+      timestamp: 1613063089,
+      recipient: 'cool.person@company.com',
+      href: 'https://example.com',
+    }),
+  );
+});
+
 ID_INPUTS.forEach(([input, expected]) => {
   test(`#trackPageView works for ${input}`, (t) => {
     sinon.stub(t.context.client.request, 'post');


### PR DESCRIPTION
Adds a function for reporting metrics 
https://docs.customer.io/api/track/#operation/metrics