### PR TITLE
feat: Add `body` property to `SendEmailRequestWithTemplate` type definition

### DIFF
--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -11,6 +11,7 @@ export type SendEmailRequestOptionalOptions = Partial<{
   preheader: string;
   reply_to: string;
   bcc: string;
+  body: string;
   body_plain: string;
   body_amp: string;
   fake_bcc: boolean;


### PR DESCRIPTION
## Summary

* `body` can be sent for emails with a template, but the type definition hasn't been updated

<img width="1068" height="449" alt="image" src="https://github.com/user-attachments/assets/4199a4a6-b7d1-47ab-89f5-7ebb6df9eee4" />

https://docs.customer.io/journeys/transactional-email/#examples-and-api-parameters

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 0cfcc5c93b99dcc1442e0c4561b08fbaebc6d3b3. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->