### PR TITLE
add support for sending transactional in-app messages

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,7 +1,13 @@
 import type { RequestOptions } from 'https';
 import Request, { BearerAuth, RequestData } from './request';
 import { Region, RegionUS } from './regions';
-import { SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest } from './api/requests';
+import {
+  SendEmailRequest,
+  SendPushRequest,
+  SendSMSRequest,
+  SendInboxMessageRequest,
+  SendInAppRequest,
+} from './api/requests';
 import { cleanEmail, isEmpty, isIdentifierType, MissingParamError } from './utils';
 import { Filter, IdentifierType } from './types';
 
@@ -101,6 +107,14 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/inbox_message`, req.message);
   }
 
+  sendInApp(req: SendInAppRequest) {
+    if (!(req instanceof SendInAppRequest)) {
+      throw new Error('"request" must be an instance of SendInAppRequest');
+    }
+
+    return this.request.post(`${this.apiRoot}/send/in_app`, req.message);
+  }
+
   getCustomersByEmail(email: string) {
     if (typeof email !== 'string' || isEmpty(email)) {
       throw new Error('"email" must be a string');
@@ -176,4 +190,10 @@ export class APIClient {
   }
 }
 
-export { SendEmailRequest, SendPushRequest, SendSMSRequest, SendInboxMessageRequest } from './api/requests';
+export {
+  SendEmailRequest,
+  SendPushRequest,
+  SendSMSRequest,
+  SendInboxMessageRequest,
+  SendInAppRequest,
+} from './api/requests';

--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -238,3 +238,36 @@ export class SendInboxMessageRequest {
     };
   }
 }
+
+export type InAppMessage = Partial<SendInAppRequestOptions>;
+
+export type SendInAppRequestRequiredOptions = {
+  identifiers: Identifiers;
+  transactional_message_id: string | number;
+};
+
+export type SendInAppRequestOptionalOptions = Partial<{
+  disable_message_retention: boolean;
+  queue_draft: boolean;
+  message_data: Record<string, any>;
+  send_at: number;
+  language: string;
+}>;
+
+export type SendInAppRequestOptions = SendInAppRequestRequiredOptions & SendInAppRequestOptionalOptions & {};
+
+export class SendInAppRequest {
+  message: InAppMessage;
+
+  constructor(opts: SendInAppRequestOptions) {
+    this.message = {
+      identifiers: opts.identifiers,
+      transactional_message_id: opts.transactional_message_id,
+      disable_message_retention: opts.disable_message_retention,
+      queue_draft: opts.queue_draft,
+      message_data: opts.message_data,
+      send_at: opts.send_at,
+      language: opts.language,
+    };
+  }
+}

--- a/test/api.ts
+++ b/test/api.ts
@@ -8,6 +8,7 @@ import {
   SendPushRequest,
   SendSMSRequest,
   SendInboxMessageRequest,
+  SendInAppRequest,
 } from '../lib/api';
 import { RegionUS, RegionEU } from '../lib/regions';
 import { Filter, IdentifierType } from '../lib/types';
@@ -645,4 +646,76 @@ test('#sendInboxMessage: error', async (t) => {
   t.truthy(
     (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/inbox_message`, req.message),
   );
+});
+
+test('sendInApp: passing in a plain object throws an error', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+
+  let req = { identifiers: { id: '2' }, transactional_message_id: 1 };
+
+  t.throws(() => t.context.client.sendInApp(req as any), {
+    message: /"request" must be an instance of SendInAppRequest/,
+  });
+  t.falsy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`));
+});
+
+test('#sendInApp: with template: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendInAppRequest({
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+  });
+  t.context.client.sendInApp(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`, req.message));
+  t.is(req.message.transactional_message_id, 1);
+  t.deepEqual(req.message.identifiers, { id: '2' });
+});
+
+test('#sendInApp: with optional parameters: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendInAppRequest({
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+    message_data: { key: 'value' },
+    disable_message_retention: true,
+    queue_draft: true,
+    send_at: 1234567890,
+    language: 'en',
+  });
+  t.context.client.sendInApp(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`, req.message));
+  t.is(req.message.transactional_message_id, 1);
+  t.deepEqual(req.message.identifiers, { id: '2' });
+  t.deepEqual(req.message.message_data, { key: 'value' });
+  t.true(req.message.disable_message_retention);
+  t.true(req.message.queue_draft);
+  t.is(req.message.send_at, 1234567890);
+  t.is(req.message.language, 'en');
+});
+
+test('#sendInApp: with email identifier: success', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendInAppRequest({
+    identifiers: { email: 'test@example.com' },
+    transactional_message_id: 1,
+  });
+  t.context.client.sendInApp(req);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`, req.message));
+  t.is(req.message.transactional_message_id, 1);
+  t.deepEqual(req.message.identifiers, { email: 'test@example.com' });
+});
+
+test('#sendInApp: error', async (t) => {
+  sinon.stub(t.context.client.request, 'post').rejects({ message: 'sample error', statusCode: 400 });
+
+  let req = new SendInAppRequest({
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+  });
+  t.context.client.sendInApp(req).catch((err) => {
+    t.is(err.message, 'sample error');
+    t.is(err.statusCode, 400);
+  });
+
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`, req.message));
 });


### PR DESCRIPTION
Adds `SendInAppRequest` and `sendInApp` method to the API client for the `POST /v1/send/in_app` endpoint. Follows the same pattern as the existing inbox message support.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `sendInApp` client method and request type following existing message patterns, with tests covering success/error cases.
> 
> **Overview**
> Adds support for sending transactional in-app messages via a new `SendInAppRequest` and `APIClient.sendInApp`, posting to the `POST /send/in_app` endpoint.
> 
> Exports the new request type from `lib/api.ts` and adds AVA tests that mirror the existing inbox-message flow (type-checking, optional params, email identifier support, and error propagation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39099ff00326f420085ba050887177d7812b6c36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->