### PR TITLE
Update supported node versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,19 +6,17 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        node: ["14", "15", "16", "17", "18" ]
+        # Supported Node.js versions: current + Active LTS + Maintenance LTS.
+        # See https://nodejs.org/en/about/previous-releases
+        node: ["22", "24", "26"]
     steps:
       - uses: actions/checkout@v4
       - name: setup node
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
-      - uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: customerio-${{ matrix.node }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            customerio-${{ matrix.node }}
+          cache: npm
       - run: npm ci
       - run: npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+#### Changed
+
+- **BREAKING:** Drop support for Node.js versions that have reached end-of-life. Supported versions now follow the [Node.js release schedule](https://nodejs.org/en/about/previous-releases) — Current, Active LTS, and Maintenance LTS only (currently Node.js 22, 24, and 26). Added an `engines` field to `package.json`.
+
 ## [4.4.0]
 
 #### Added

--- a/README.md
+++ b/README.md
@@ -11,9 +11,15 @@
 
 A node client for the Customer.io Journeys [REST API](https://customer.io/docs/api/). If you're new to Customer.io, we recommend that you integrate with our [Data Pipelines JavaScript client](https://github.com/customerio/cdp-analytics-js) instead.
 
+## Supported Node.js versions
+
+This project is developed for and tested against the versions of Node.js that the Node.js project itself supports — the **Current** release plus the **Active LTS** and **Maintenance LTS** lines. See the [Node.js release schedule](https://nodejs.org/en/about/previous-releases) for details. When a Node.js version reaches end-of-life, support for it is dropped in the next release of this library, which may be a breaking change.
+
+The `engines` field in `package.json` reflects the current minimum supported version.
+
 ## Alternative Node runtimes
 
-This project is developed for and tested against the latest and LTS versions of Node.js. Many runtimes often have subtle differences to the APIs and standard library offered by Node.js. These differences can cause issues when using this library with those runtimes.
+Many runtimes often have subtle differences to the APIs and standard library offered by Node.js. These differences can cause issues when using this library with those runtimes.
 
 If you would like to use Customer.io with an alternate runtime, we recommend using either our [Track](https://customer.io/docs/api/#tag/trackOverview) and [App](https://customer.io/docs/api/#tag/appOverview) APIs directly using the built-in HTTP client available in your runtime, or our [React Native SDK](https://customer.io/docs/sdk/react-native/getting-started/) if applicable.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.4.0",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^17.0.36",
+        "@types/node": "^22.0.0",
         "@types/sinon": "^10.0.2",
         "ava": "^5.0.1",
         "husky": "^8.0.1",
@@ -19,6 +19,9 @@
         "sinon": "^14.0.0",
         "ts-node": "^10.9.1",
         "typescript": "^4.9.4"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -676,10 +679,14 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-      "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
-      "dev": true
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/sinon": {
       "version": "10.0.11",
@@ -3808,6 +3815,13 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
@@ -4521,10 +4535,13 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.36.tgz",
-      "integrity": "sha512-V3orv+ggDsWVHP99K3JlwtH20R7J4IhI1Kksgc+64q5VxgfRkQG8Ws3MFm/FZOKDYGy9feGFlZ70/HpCNe9QaA==",
-      "dev": true
+      "version": "22.19.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.18.tgz",
+      "integrity": "sha512-9v00a+dn2yWVsYDEunWC4g/TcRKVq3r8N5FuZp7u0SGrPvdN9c2yXI9bBuf5Fl0hNCb+QTIePTn5pJs2pwBOQQ==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~6.21.0"
+      }
     },
     "@types/sinon": {
       "version": "10.0.11",
@@ -6759,6 +6776,12 @@
       "version": "4.9.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
       "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true
     },
     "uuid": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,11 @@
     "statements": 100
   },
   "bugs": "https://github.com/customerio/customerio-node/issues",
+  "engines": {
+    "node": ">=22"
+  },
   "devDependencies": {
-    "@types/node": "^17.0.36",
+    "@types/node": "^22.0.0",
     "@types/sinon": "^10.0.2",
     "ava": "^5.0.1",
     "husky": "^8.0.1",


### PR DESCRIPTION
This updates the node testing matrix to include the current + LTS versions of node.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises the minimum supported Node.js version to 22 and updates CI to only test current/LTS lines, which is a breaking compatibility change for consumers on older Node versions.
> 
> **Overview**
> Updates supported Node.js versions to follow the Node release schedule (Current + Active LTS + Maintenance LTS), **dropping EOL versions**.
> 
> CI now tests only Node `22`, `24`, and `26`, disables matrix fail-fast, and switches to `actions/setup-node`’s built-in `npm` caching. The package now declares `engines.node: ">=22"`, bumps `@types/node` accordingly, and documents the breaking support change in `CHANGELOG.md` and `README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a56b3cb83af9c046bfff06f025a691554eaae90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->