### PR TITLE
Release v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [4.5.0]
 
 #### Changed
 
-- **BREAKING:** Drop support for Node.js versions that have reached end-of-life. Supported versions now follow the [Node.js release schedule](https://nodejs.org/en/about/previous-releases) — Current, Active LTS, and Maintenance LTS only (currently Node.js 22, 24, and 26). Added an `engines` field to `package.json`.
+- **BREAKING:** Drop support for Node.js versions that have reached end-of-life. Supported versions now follow the [Node.js release schedule](https://nodejs.org/en/about/previous-releases) — Current, Active LTS, and Maintenance LTS only (currently Node.js 22, 24, and 26). Added an `engines` field to `package.json`. ([#180](https://github.com/customerio/customerio-node/pull/180))
+- **BREAKING:** Fix `triggerBroadcast` API path by removing erroneous `/api` prefix, and rename the `id` parameter to `broadcastId` for clarity ([#179](https://github.com/customerio/customerio-node/pull/179))
+- Bump third-party dependencies: `@types/node`, `@types/sinon`, `ava`, `js-yaml`, `lodash`, `minimatch`, `nyc`, `picomatch`, `pretty-quick`, `sinon` ([#167](https://github.com/customerio/customerio-node/pull/167), [#169](https://github.com/customerio/customerio-node/pull/169), [#177](https://github.com/customerio/customerio-node/pull/177), [#178](https://github.com/customerio/customerio-node/pull/178), [#181](https://github.com/customerio/customerio-node/pull/181))
+
+#### Added
+
+- Add `body` property to `SendEmailRequestWithTemplate` type definition ([#172](https://github.com/customerio/customerio-node/pull/172))
+
+#### Fixed
+
+- Add timeout handling for HTTP requests ([#173](https://github.com/customerio/customerio-node/pull/173))
 
 ## [4.4.0]
 

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '4.4.0';
+export const version = '4.5.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-node",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-node",
-      "version": "4.4.0",
+      "version": "4.5.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
#### Changed

- **BREAKING:** Drop support for Node.js versions that have reached end-of-life. Supported versions now follow the [Node.js release schedule](https://nodejs.org/en/about/previous-releases) — Current, Active LTS, and Maintenance LTS only (currently Node.js 22, 24, and 26). Added an `engines` field to `package.json`. ([#180](https://github.com/customerio/customerio-node/pull/180))
- **BREAKING:** Fix `triggerBroadcast` API path by removing erroneous `/api` prefix, and rename the `id` parameter to `broadcastId` for clarity ([#179](https://github.com/customerio/customerio-node/pull/179))
- Bump third-party dependencies: `@types/node`, `@types/sinon`, `ava`, `js-yaml`, `lodash`, `minimatch`, `nyc`, `picomatch`, `pretty-quick`, `sinon` ([#167](https://github.com/customerio/customerio-node/pull/167), [#169](https://github.com/customerio/customerio-node/pull/169), [#177](https://github.com/customerio/customerio-node/pull/177), [#178](https://github.com/customerio/customerio-node/pull/178), [#181](https://github.com/customerio/customerio-node/pull/181))

#### Added

- Add `body` property to `SendEmailRequestWithTemplate` type definition ([#172](https://github.com/customerio/customerio-node/pull/172))

#### Fixed

- Add timeout handling for HTTP requests ([#173](https://github.com/customerio/customerio-node/pull/173))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a version/changelog release update; runtime risk is low, but the documented Node.js support drop is breaking for consumers on older Node versions.
> 
> **Overview**
> Cuts release `4.5.0` by bumping the package/version constants (`package.json`, `package-lock.json`, `lib/version.ts`) and updating `CHANGELOG.md` with the 4.5.0 notes.
> 
> The release notes document **breaking** Node.js support changes (now `node >=22` via `engines`), plus prior fixes/additions like `triggerBroadcast` path/param corrections, dependency bumps, an added `SendEmailRequestWithTemplate.body` type, and HTTP request timeout handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54bb1b11b826616f5a657919976dabfb236a69ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->