### PR TITLE
Add workflow for trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: publish
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
Following the guide from https://docs.npmjs.com/trusted-publishers this adds a `publish.yml` workflow to publish a new version on npm when a new release is created.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds automated npm publishing on GitHub Release publish events, which impacts the project’s release/distribution pipeline and could publish unintended versions if misconfigured.
> 
> **Overview**
> Automatically publishes the package to npm whenever a GitHub Release is published via a new `publish` GitHub Actions workflow.
> 
> The workflow sets minimal OIDC permissions (`id-token: write`), installs dependencies, runs `build` and `test`, and runs `npm publish --provenance --access public` using Node `24`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23ee81374ead39938024bcd660b606112e2b09d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->