### PR TITLE
Fix redirect handler shadowing request body with response body

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -83,7 +83,7 @@ export default class CIORequest {
         });
 
         res.on('end', () => {
-          let body = Buffer.concat(chunks).toString('utf-8');
+          let responseBody = Buffer.concat(chunks).toString('utf-8');
           let json: Record<string, any> = {};
 
           if ([301, 302, 307, 308].includes(res.statusCode ?? 0)) {
@@ -97,11 +97,11 @@ export default class CIORequest {
           }
 
           try {
-            if (body && body.length) {
-              json = JSON.parse(body);
+            if (responseBody && responseBody.length) {
+              json = JSON.parse(responseBody);
             }
           } catch (error) {
-            const message = `Unable to parse JSON. Error: ${error} \nBody:\n ${body}`;
+            const message = `Unable to parse JSON. Error: ${error} \nBody:\n ${responseBody}`;
 
             return reject(new Error(message));
           }
@@ -109,7 +109,7 @@ export default class CIORequest {
           if (res.statusCode == 200 || res.statusCode == 201) {
             resolve(json);
           } else {
-            reject(new CustomerIORequestError(json, res.statusCode || 0, res, body));
+            reject(new CustomerIORequestError(json, res.statusCode || 0, res, responseBody));
           }
         });
       });

--- a/test/request.ts
+++ b/test/request.ts
@@ -445,6 +445,51 @@ test.serial('#handler makes a request and follows redirects', async (t) => {
   }
 });
 
+test.serial('#handler forwards the original request body across redirects', async (t) => {
+  const usResponse = new PassThrough();
+  const usRequest = new PassThrough();
+  const euResponse = new PassThrough();
+  const euRequest = new PassThrough();
+  const originalBody = JSON.stringify(data);
+  const customOptions = Object.assign({}, baseOptions, {
+    method: 'PUT',
+    body: originalBody,
+  });
+
+  // Capture what gets written to the second (redirected) request
+  let euRequestBody = '';
+  euRequest.on('data', (chunk: Buffer) => {
+    euRequestBody += chunk.toString('utf-8');
+  });
+
+  usRequest.on('finish', () => {
+    (usResponse as any).statusCode = 301;
+    (usResponse as any).headers = { location: 'https://track-eu.customer.io/api/v1/customers/1' };
+    // Write a non-empty response body to make sure we don't accidentally
+    // forward *this* as the next request body.
+    usResponse.write('redirect-response-body-not-a-payload');
+    usResponse.end();
+  });
+  euRequest.on('finish', () => {
+    (euResponse as any).statusCode = 200;
+    (euResponse as any).headers = {};
+    euResponse.write(JSON.stringify({ ok: true }));
+    euResponse.end();
+  });
+
+  t.context.httpsReq
+    .withArgs(sinon.match.any)
+    .callsArgWith(1, usResponse)
+    .returns(usRequest as any)
+    .withArgs(sinon.match.has('hostname', 'track-eu.customer.io'))
+    .callsArgWith(1, euResponse)
+    .returns(euRequest as any);
+
+  await t.context.req.handler(customOptions);
+
+  t.is(euRequestBody, originalBody);
+});
+
 test.serial('#handler makes a request and errors when redirecting without a location header', async (t) => {
   const usResponse = new PassThrough();
   const usRequest = new PassThrough();


### PR DESCRIPTION
The end-of-response handler declared `let body = ...` for the response payload, which shadowed the outer `body` parameter destructured from RequestHandlerOptions. On a 3xx, the recursive handler() call forwarded that response body as the next request body, silently dropping the original payload (identify/track/sendEmail data was lost on redirect).

Rename the inner variable to `responseBody` so the original request body is forwarded across redirects, and add a regression test that asserts the second hop receives the original payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small rename fixes redirect payload propagation and adds a focused regression test; behavior change is limited to 3xx redirect handling.
> 
> **Overview**
> Fixes a redirect-handling bug in `CIORequest.handler` where the response body variable shadowed the original request `body`, causing redirected requests to send the *redirect response payload* instead of the intended JSON payload.
> 
> Renames the inner response buffer to `responseBody` and adds a regression test asserting the second hop receives the original request body across a 301 redirect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a70cc91b0a86726896c99afde954199b31b0653c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->