### PR TITLE
Strip `Authorization` header on non-customer.io redirects

### DIFF
--- a/lib/request.ts
+++ b/lib/request.ts
@@ -93,7 +93,23 @@ export default class CIORequest {
               return reject(new Error(`Received a ${res.statusCode} status, but no Location header was present`));
             }
 
-            return this.handler({ uri: newURI, body, method, headers }).then(resolve).catch(reject);
+            // Strip the Authorization header when the redirect target is not a
+            // customer.io host, so we don't leak credentials to a host the
+            // caller never intended to authenticate against. Cross-data-center
+            // redirects (e.g. US → EU) stay within `*.customer.io` and must
+            // continue to carry the Authorization header.
+            let redirectHeaders = headers;
+            try {
+              const newHostname = new URL(newURI).hostname;
+              if (!newHostname.endsWith('.customer.io') && headers && 'Authorization' in headers) {
+                const { Authorization: _stripped, ...rest } = headers as Record<string, unknown>;
+                redirectHeaders = rest as RequestOptions['headers'];
+              }
+            } catch (err) {
+              // No need to do anything if the URL is malformed or relative
+            }
+
+            return this.handler({ uri: newURI, body, method, headers: redirectHeaders }).then(resolve).catch(reject);
           }
 
           try {

--- a/test/request.ts
+++ b/test/request.ts
@@ -490,6 +490,87 @@ test.serial('#handler forwards the original request body across redirects', asyn
   t.is(euRequestBody, originalBody);
 });
 
+test.serial('#handler strips the Authorization header on redirects to non-customer.io hosts', async (t) => {
+  const usResponse = new PassThrough();
+  const usRequest = new PassThrough();
+  const evilResponse = new PassThrough();
+  const evilRequest = new PassThrough();
+  const customOptions = Object.assign({}, baseOptions, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+    timeout: 1,
+  });
+  const body = { redirected: true };
+
+  usRequest.on('finish', () => {
+    (usResponse as any).statusCode = 301;
+    (usResponse as any).headers = { location: 'https://evil.example.com/api/v1/customers/1' };
+    usResponse.end();
+  });
+  evilRequest.on('finish', () => {
+    (evilResponse as any).statusCode = 200;
+    (evilResponse as any).headers = {};
+    evilResponse.write(JSON.stringify(body));
+    evilResponse.end();
+  });
+
+  t.context.httpsReq
+    .withArgs(sinon.match.any)
+    .callsArgWith(1, usResponse)
+    .returns(usRequest as any)
+    .withArgs(sinon.match.has('hostname', 'evil.example.com'))
+    .callsArgWith(1, evilResponse)
+    .returns(evilRequest as any);
+
+  const res = await t.context.req.handler(customOptions);
+  t.deepEqual(res, body);
+  t.is(t.context.httpsReq.callCount, 2);
+
+  const secondCallArgs = t.context.httpsReq.getCall(1).args[0] as { headers: Record<string, string | undefined> };
+  t.false('Authorization' in secondCallArgs.headers);
+  t.is(secondCallArgs.headers.Authorization, undefined);
+});
+
+test.serial('#handler preserves the Authorization header on redirects within *.customer.io', async (t) => {
+  const usResponse = new PassThrough();
+  const usRequest = new PassThrough();
+  const euResponse = new PassThrough();
+  const euRequest = new PassThrough();
+  const customOptions = Object.assign({}, baseOptions, {
+    method: 'PUT',
+    body: JSON.stringify(data),
+    timeout: 1,
+  });
+  const body = { redirected: true };
+
+  usRequest.on('finish', () => {
+    (usResponse as any).statusCode = 301;
+    (usResponse as any).headers = { location: 'https://track-eu.customer.io/api/v1/customers/1' };
+    usResponse.end();
+  });
+  euRequest.on('finish', () => {
+    (euResponse as any).statusCode = 200;
+    (euResponse as any).headers = {};
+    euResponse.write(JSON.stringify(body));
+    euResponse.end();
+  });
+
+  t.context.httpsReq
+    .withArgs(sinon.match.any)
+    .callsArgWith(1, usResponse)
+    .returns(usRequest as any)
+    .withArgs(sinon.match.has('hostname', 'track-eu.customer.io'))
+    .callsArgWith(1, euResponse)
+    .returns(euRequest as any);
+
+  const res = await t.context.req.handler(customOptions);
+  t.deepEqual(res, body);
+  t.is(t.context.httpsReq.callCount, 2);
+
+  const secondCallArgs = t.context.httpsReq.getCall(1).args[0] as { headers: Record<string, string> };
+  t.is(secondCallArgs.headers.Authorization, trackAuth);
+});
+
 test.serial('#handler makes a request and errors when redirecting without a location header', async (t) => {
   const usResponse = new PassThrough();
   const usRequest = new PassThrough();


### PR DESCRIPTION
The request handler followed 3xx redirects with the original headers intact, including `Authorization`. If the API ever redirected to a host outside the customer.io domain (misconfig, DNS hijack, MITM on a plain HTTP redirect), the basic-auth or bearer credential would leak to that host.

Strip the `Authorization` header when the redirect target's hostname does not end with `.customer.io`. Cross-data-center redirects (US → EU between `*.customer.io` hosts) must continue to carry the header for the SDK to keep working across regions, so we explicitly allow them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes redirect behavior in the HTTP request path and could affect integrations that rely on cross-domain redirects, though it is narrowly scoped and covered by new tests.
> 
> **Overview**
> Prevents credential leakage when following 3xx redirects by **removing the `Authorization` header** if the redirect target hostname is outside `*.customer.io`, while **preserving auth for in-domain (e.g. US→EU) redirects**.
> 
> Adds regression tests ensuring `Authorization` is stripped for external hosts and retained for `*.customer.io` redirects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b459bee6b0ce48c3ef5edd0391caf45223c4b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->