### PR TITLE
CDP-5965: URL-encode path parameters in APIClient

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -138,7 +138,7 @@ export class APIClient {
       };
     }
 
-    return this.request.post(`${this.apiRoot}/campaigns/${broadcastId}/triggers`, payload);
+    return this.request.post(`${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers`, payload);
   }
 
   listExports() {
@@ -150,7 +150,7 @@ export class APIClient {
       throw new MissingParamError('id');
     }
 
-    return this.request.get(`${this.apiRoot}/exports/${id}`);
+    return this.request.get(`${this.apiRoot}/exports/${encodeURIComponent(id)}`);
   }
 
   downloadExport(id: string | number) {
@@ -158,7 +158,7 @@ export class APIClient {
       throw new MissingParamError('id');
     }
 
-    return this.request.get(`${this.apiRoot}/exports/${id}/download`);
+    return this.request.get(`${this.apiRoot}/exports/${encodeURIComponent(id)}/download`);
   }
 
   createCustomersExport(filters: Filter) {
@@ -186,7 +186,7 @@ export class APIClient {
       throw new Error('idType must be one of "id", "cio_id", or "email"');
     }
 
-    return this.request.get(`${this.apiRoot}/customers/${id}/attributes?id_type=${idType}`);
+    return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(id)}/attributes?id_type=${idType}`);
   }
 }
 

--- a/test/api.ts
+++ b/test/api.ts
@@ -498,7 +498,7 @@ test('#getAttributes: success with type email', (t) => {
   t.context.client.getAttributes('test@email.com', IdentifierType.Email);
   t.truthy(
     (t.context.client.request.get as SinonStub).calledWith(
-      `${RegionUS.apiUrl}/customers/test@email.com/attributes?id_type=email`,
+      `${RegionUS.apiUrl}/customers/${encodeURIComponent('test@email.com')}/attributes?id_type=email`,
     ),
   );
 });
@@ -718,4 +718,46 @@ test('#sendInApp: error', async (t) => {
   });
 
   t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/in_app`, req.message));
+});
+
+const ID_INPUTS: [string | number, string][] = [
+  [1, '1'],
+  ['2 ', encodeURIComponent('2 ')],
+  ['3/', encodeURIComponent('3/')],
+  ['%&*/test.#@!~', encodeURIComponent('%&*/test.#@!~')],
+];
+
+ID_INPUTS.forEach(([input, expected]) => {
+  test(`#triggerBroadcast: encodes broadcastId ${input}`, (t) => {
+    sinon.stub(t.context.client.request, 'post');
+    t.context.client.triggerBroadcast(input, { type: 'data' }, { type: 'recipients' });
+    t.truthy(
+      (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/campaigns/${expected}/triggers`, {
+        data: { type: 'data' },
+        recipients: { type: 'recipients' },
+      }),
+    );
+  });
+
+  test(`#getExport: encodes id ${input}`, (t) => {
+    sinon.stub(t.context.client.request, 'get');
+    t.context.client.getExport(input);
+    t.truthy((t.context.client.request.get as SinonStub).calledWith(`${RegionUS.apiUrl}/exports/${expected}`));
+  });
+
+  test(`#downloadExport: encodes id ${input}`, (t) => {
+    sinon.stub(t.context.client.request, 'get');
+    t.context.client.downloadExport(input);
+    t.truthy((t.context.client.request.get as SinonStub).calledWith(`${RegionUS.apiUrl}/exports/${expected}/download`));
+  });
+
+  test(`#getAttributes: encodes id ${input}`, (t) => {
+    sinon.stub(t.context.client.request, 'get');
+    t.context.client.getAttributes(input as string);
+    t.truthy(
+      (t.context.client.request.get as SinonStub).calledWith(
+        `${RegionUS.apiUrl}/customers/${expected}/attributes?id_type=id`,
+      ),
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- Add `encodeURIComponent()` to path parameters in `triggerBroadcast`, `getExport`, `downloadExport`, and `getAttributes` in `APIClient`
- Matches the existing pattern used throughout `TrackClient`, which already encodes all path parameters
- Fixes malformed URLs when IDs contain special characters (e.g. email addresses with `@`, `+`, `%`)

## Test plan
- [x] Updated existing email-identifier test to expect encoded URL
- [x] Added 16 new tests covering spaces, slashes, and special characters across all 4 methods
- [x] All 146 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only client-side URL construction for a few endpoints, with expanded tests to catch regressions. Potential impact is limited to how IDs are serialized into request paths.
> 
> **Overview**
> **What changed**: `APIClient` now applies `encodeURIComponent()` to path parameters in `triggerBroadcast`, `getExport`, `downloadExport`, and `getAttributes`, ensuring IDs like emails, spaces, and slashes produce valid request URLs.
> 
> **Tests**: Updates the existing email-identifier expectation and adds a small matrix of new tests validating encoding across these four methods.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5defe001332e9f38cbeda4d6e5c18a9233156db5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->