### PR TITLE
CDP-5966: make getCustomersByEmail query-safe (drop cleanEmail, use encodeURIComponent)

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,7 +8,7 @@ import {
   SendInboxMessageRequest,
   SendInAppRequest,
 } from './api/requests';
-import { cleanEmail, isEmpty, isIdentifierType, MissingParamError } from './utils';
+import { isEmpty, isIdentifierType, MissingParamError } from './utils';
 import { Filter, IdentifierType } from './types';
 
 type APIDefaults = RequestOptions & { region: Region; url?: string };
@@ -120,7 +120,7 @@ export class APIClient {
       throw new Error('"email" must be a string');
     }
 
-    return this.request.get(`${this.apiRoot}/customers?email=${cleanEmail(email)}`);
+    return this.request.get(`${this.apiRoot}/customers?email=${encodeURIComponent(email)}`);
   }
 
   triggerBroadcast(broadcastId: string | number, data: RequestData, recipients: Recipients) {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,8 +5,6 @@ export const isEmpty = (value: unknown) => {
   return value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
 };
 
-};
-
 export const isIdentifierType = (value: unknown) => {
   return Object.values(IdentifierType).includes(value as IdentifierType);
 };

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -5,8 +5,6 @@ export const isEmpty = (value: unknown) => {
   return value === null || value === undefined || (typeof value === 'string' && value.trim() === '');
 };
 
-export const cleanEmail = (email: string) => {
-  return email.split('@').map(encodeURIComponent).join('@');
 };
 
 export const isIdentifierType = (value: unknown) => {

--- a/test/api.ts
+++ b/test/api.ts
@@ -191,7 +191,35 @@ test('#getCustomersByEmail: searching for a customer email (default)', (t) => {
 
   const email = 'hello@world.com';
   t.context.client.getCustomersByEmail(email);
-  t.truthy((t.context.client.request.get as SinonStub).calledWith(`${RegionUS.apiUrl}/customers?email=${email}`));
+  t.truthy(
+    (t.context.client.request.get as SinonStub).calledWith(
+      `${RegionUS.apiUrl}/customers?email=${encodeURIComponent(email)}`,
+    ),
+  );
+});
+
+test('#getCustomersByEmail: encodes reserved characters in email', (t) => {
+  sinon.stub(t.context.client.request, 'get');
+
+  const email = 'user+tag&filter=1@example.com';
+  t.context.client.getCustomersByEmail(email);
+  t.truthy(
+    (t.context.client.request.get as SinonStub).calledWith(
+      `${RegionUS.apiUrl}/customers?email=${encodeURIComponent(email)}`,
+    ),
+  );
+});
+
+test('#getCustomersByEmail: encodes hash and question mark in email', (t) => {
+  sinon.stub(t.context.client.request, 'get');
+
+  const email = 'user#name?q=1@example.com';
+  t.context.client.getCustomersByEmail(email);
+  t.truthy(
+    (t.context.client.request.get as SinonStub).calledWith(
+      `${RegionUS.apiUrl}/customers?email=${encodeURIComponent(email)}`,
+    ),
+  );
 });
 
 test('#getCustomersByEmail: should throw error when email is empty', (t) => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,20 +1,5 @@
 import avaTest, { TestFn } from 'ava';
-import { cleanEmail } from '../lib/utils';
 
 type TestContext = {};
 
 const test = avaTest as TestFn<TestContext>;
-
-test('#cleanEmail correctly formats email (default)', (t) => {
-  let email = 'hello+test@world.com';
-  let result = cleanEmail(email);
-  t.is(result, 'hello%2Btest@world.com');
-
-  email = 'test@world.com';
-  result = cleanEmail(email);
-  t.is(result, 'test@world.com');
-
-  email = '';
-  result = cleanEmail(email);
-  t.is(result, '');
-});

--- a/test/util.ts
+++ b/test/util.ts
@@ -1,5 +1,0 @@
-import avaTest, { TestFn } from 'ava';
-
-type TestContext = {};
-
-const test = avaTest as TestFn<TestContext>;


### PR DESCRIPTION
## What

Fixes `getCustomersByEmail` to correctly encode the full email value in the query string. The previous `cleanEmail` helper only encoded each side of `@` separately, leaving reserved characters like `&`, `#`, and `?` unencoded — corrupting the query string.

## Changes

`lib/utils.ts` — remove `cleanEmail` helper (no other callers).

`lib/api.ts` — replace `cleanEmail(email)` with `encodeURIComponent(email)` in `getCustomersByEmail`. Remove `cleanEmail` import.

`test/util.ts` — remove `cleanEmail` tests (helper no longer exists).

`test/api.ts` — update existing default test to expect `encodeURIComponent` output. Add two new tests covering emails with reserved characters (`&`, `+`, `#`, `?`).

Closes CDP-5966.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small change to URL encoding for a single API call plus accompanying test updates; behavior only differs for emails containing reserved URL characters.
> 
> **Overview**
> Fixes `APIClient.getCustomersByEmail` to build a query-safe request by encoding the *entire* email with `encodeURIComponent` instead of the removed `cleanEmail` helper.
> 
> Removes `cleanEmail` from `lib/utils.ts`, deletes its unit test, and updates/adds `test/api.ts` coverage to assert correct encoding for reserved characters like `&`, `#`, and `?`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e4fc107fbca49059bc1d2720cb49ccd7154177c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->