### PR TITLE
CDP-5981: add v2 batch endpoint to TrackClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,31 @@ cio.unsuppress(1);
 
 - **customer_id**: String or number (required)
 
+### cio.batch(operations)
+
+Send a batch of operations (identifies, events, etc.) to the [v2 batch endpoint](https://customer.io/docs/api/track/#operation/batch) in a single request. `operations` is an array of operation objects shaped per the API docs.
+
+```javascript
+cio.batch([
+  {
+    type: "person",
+    action: "identify",
+    identifiers: { id: "1" },
+    attributes: { plan: "pro" },
+  },
+  {
+    type: "person",
+    action: "event",
+    identifiers: { id: "1" },
+    name: "signup",
+  },
+]);
+```
+
+#### Options
+
+- **operations**: Array of operation objects (required, non-empty)
+
 ### Using Promises
 
 All calls to the library will return a native promise, allowing you to chain calls as such:

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -1,9 +1,11 @@
 export class Region {
   readonly trackUrl: string;
+  readonly trackV2Url: string;
   readonly apiUrl: string;
 
   constructor(trackUrl: string, apiUrl: string) {
     this.trackUrl = trackUrl;
+    this.trackV2Url = trackUrl.replace('/api/v1', '/api/v2');
     this.apiUrl = apiUrl;
   }
 }

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -27,7 +27,9 @@ export class TrackClient {
     this.request = new Request({ siteid: this.siteid, apikey: this.apikey }, this.defaults);
 
     this.trackRoot = this.defaults.url ? this.defaults.url : this.defaults.region.trackUrl;
-    this.trackV2Root = this.trackRoot.replace('/api/v1', '/api/v2');
+    this.trackV2Root = this.defaults.url
+      ? this.defaults.url.replace('/api/v1', '/api/v2')
+      : this.defaults.region.trackV2Url;
   }
 
   identify(customerId: string | number, data: RequestData = {}) {

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -6,12 +6,15 @@ import { IdentifierType } from './types';
 
 type TrackDefaults = RequestOptions & { region: Region; url?: string };
 
+export type BatchOperation = Record<string, any>;
+
 export class TrackClient {
   siteid: BasicAuth['siteid'];
   apikey: BasicAuth['apikey'];
   defaults: TrackDefaults;
   request: Request;
   trackRoot: string;
+  trackV2Root: string;
 
   constructor(siteid: BasicAuth['siteid'], apikey: BasicAuth['apikey'], defaults: Partial<TrackDefaults> = {}) {
     if (defaults.region && !(defaults.region instanceof Region)) {
@@ -24,6 +27,7 @@ export class TrackClient {
     this.request = new Request({ siteid: this.siteid, apikey: this.apikey }, this.defaults);
 
     this.trackRoot = this.defaults.url ? this.defaults.url : this.defaults.region.trackUrl;
+    this.trackV2Root = this.trackRoot.replace('/api/v1', '/api/v2');
   }
 
   identify(customerId: string | number, data: RequestData = {}) {
@@ -140,6 +144,14 @@ export class TrackClient {
     return this.request.destroy(
       `${this.trackRoot}/customers/${encodeURIComponent(customerId)}/devices/${encodeURIComponent(deviceToken)}`,
     );
+  }
+
+  batch(operations: BatchOperation[]) {
+    if (!Array.isArray(operations) || operations.length === 0) {
+      throw new MissingParamError('operations');
+    }
+
+    return this.request.post(`${this.trackV2Root}/batch`, { batch: operations });
   }
 
   mergeCustomers(

--- a/test/track.ts
+++ b/test/track.ts
@@ -23,6 +23,7 @@ test('constructor sets necessary variables', (t) => {
   t.is(t.context.client.siteid, '123');
   t.is(t.context.client.apikey, 'abc');
   t.is(t.context.client.trackRoot, RegionUS.trackUrl);
+  t.is(t.context.client.trackV2Root, RegionUS.trackUrl.replace('/api/v1', '/api/v2'));
 
   t.truthy(t.context.client.request);
   t.is(t.context.client.request.siteid, '123');
@@ -36,6 +37,7 @@ test('constructor sets correct URL for different regions', (t) => {
     t.is(client.siteid, '123');
     t.is(client.apikey, 'abc');
     t.is(client.trackRoot, region.trackUrl);
+    t.is(client.trackV2Root, region.trackUrl.replace('/api/v1', '/api/v2'));
 
     t.truthy(client.request);
     t.is(client.request.siteid, '123');
@@ -49,6 +51,7 @@ test('constructor sets correct URL for custom URL', (t) => {
   t.is(client.siteid, '123');
   t.is(client.apikey, 'abc');
   t.is(client.trackRoot, 'https://example.com/url');
+  t.is(client.trackV2Root, 'https://example.com/url');
 
   t.truthy(client.request);
   t.is(client.request.siteid, '123');
@@ -298,4 +301,37 @@ test('#mergeCustomers: fails if id_type is not id, cio_id nor email', (t) => {
   t.throws(() => (t.context.client.mergeCustomers as any)(IdentifierType.Id, 'id1', undefined, 'id2'), {
     message: 'primaryIdType and secondaryIdType must be one of "id", "cio_id", or "email"',
   });
+});
+
+test('#batch posts to /api/v2/batch with the operations array', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  const operations = [
+    { type: 'person', identifiers: { id: '1' }, action: 'identify', attributes: { plan: 'pro' } },
+    { type: 'person', identifiers: { id: '1' }, action: 'event', name: 'signup' },
+  ];
+
+  t.context.client.batch(operations);
+
+  const expectedUrl = `${RegionUS.trackUrl.replace('/api/v1', '/api/v2')}/batch`;
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(expectedUrl, { batch: operations }));
+});
+
+test('#batch uses the EU v2 root when constructed with RegionEU', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionEU });
+  sinon.stub(client.request, 'post');
+  const operations = [{ type: 'person', identifiers: { id: '1' }, action: 'identify' }];
+
+  client.batch(operations);
+
+  const expectedUrl = `${RegionEU.trackUrl.replace('/api/v1', '/api/v2')}/batch`;
+  t.truthy((client.request.post as SinonStub).calledWith(expectedUrl, { batch: operations }));
+});
+
+test('#batch throws when operations is empty', (t) => {
+  t.throws(() => t.context.client.batch([]), { message: 'operations is required' });
+});
+
+test('#batch throws when operations is not an array', (t) => {
+  t.throws(() => (t.context.client.batch as any)(undefined), { message: 'operations is required' });
+  t.throws(() => (t.context.client.batch as any)({ batch: [] }), { message: 'operations is required' });
 });

--- a/test/track.ts
+++ b/test/track.ts
@@ -22,27 +22,26 @@ const ID_INPUTS = Object.freeze([
 test('constructor sets necessary variables', (t) => {
   t.is(t.context.client.siteid, '123');
   t.is(t.context.client.apikey, 'abc');
-  t.is(t.context.client.trackRoot, RegionUS.trackUrl);
-  t.is(t.context.client.trackV2Root, RegionUS.trackUrl.replace('/api/v1', '/api/v2'));
+  t.is(t.context.client.trackRoot, 'https://track.customer.io/api/v1');
+  t.is(t.context.client.trackV2Root, 'https://track.customer.io/api/v2');
 
   t.truthy(t.context.client.request);
   t.is(t.context.client.request.siteid, '123');
   t.is(t.context.client.request.apikey, 'abc');
 });
 
-test('constructor sets correct URL for different regions', (t) => {
-  [RegionUS, RegionEU].forEach((region) => {
-    let client = new TrackClient('123', 'abc', { region });
+test('constructor sets correct URL for RegionUS', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionUS });
 
-    t.is(client.siteid, '123');
-    t.is(client.apikey, 'abc');
-    t.is(client.trackRoot, region.trackUrl);
-    t.is(client.trackV2Root, region.trackUrl.replace('/api/v1', '/api/v2'));
+  t.is(client.trackRoot, 'https://track.customer.io/api/v1');
+  t.is(client.trackV2Root, 'https://track.customer.io/api/v2');
+});
 
-    t.truthy(client.request);
-    t.is(client.request.siteid, '123');
-    t.is(client.request.apikey, 'abc');
-  });
+test('constructor sets correct URL for RegionEU', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionEU });
+
+  t.is(client.trackRoot, 'https://track-eu.customer.io/api/v1');
+  t.is(client.trackV2Root, 'https://track-eu.customer.io/api/v2');
 });
 
 test('constructor sets correct URL for custom URL', (t) => {
@@ -56,6 +55,13 @@ test('constructor sets correct URL for custom URL', (t) => {
   t.truthy(client.request);
   t.is(client.request.siteid, '123');
   t.is(client.request.apikey, 'abc');
+});
+
+test('constructor swaps /api/v1 to /api/v2 in a custom URL when present', (t) => {
+  let client = new TrackClient('123', 'abc', { url: 'https://example.com/api/v1' });
+
+  t.is(client.trackRoot, 'https://example.com/api/v1');
+  t.is(client.trackV2Root, 'https://example.com/api/v2');
 });
 
 test('passing in an invalid region throws an error', (t) => {
@@ -304,7 +310,7 @@ test('#mergeCustomers: fails if id_type is not id, cio_id nor email', (t) => {
 });
 
 test('#batch posts to /api/v2/batch with the operations array', (t) => {
-  sinon.stub(t.context.client.request, 'post');
+  const post = sinon.stub(t.context.client.request, 'post');
   const operations = [
     { type: 'person', identifiers: { id: '1' }, action: 'identify', attributes: { plan: 'pro' } },
     { type: 'person', identifiers: { id: '1' }, action: 'event', name: 'signup' },
@@ -312,19 +318,19 @@ test('#batch posts to /api/v2/batch with the operations array', (t) => {
 
   t.context.client.batch(operations);
 
-  const expectedUrl = `${RegionUS.trackUrl.replace('/api/v1', '/api/v2')}/batch`;
-  t.truthy((t.context.client.request.post as SinonStub).calledWith(expectedUrl, { batch: operations }));
+  t.true(post.calledOnce);
+  t.true(post.calledWith('https://track.customer.io/api/v2/batch', { batch: operations }));
 });
 
 test('#batch uses the EU v2 root when constructed with RegionEU', (t) => {
   let client = new TrackClient('123', 'abc', { region: RegionEU });
-  sinon.stub(client.request, 'post');
+  const post = sinon.stub(client.request, 'post');
   const operations = [{ type: 'person', identifiers: { id: '1' }, action: 'identify' }];
 
   client.batch(operations);
 
-  const expectedUrl = `${RegionEU.trackUrl.replace('/api/v1', '/api/v2')}/batch`;
-  t.truthy((client.request.post as SinonStub).calledWith(expectedUrl, { batch: operations }));
+  t.true(post.calledOnce);
+  t.true(post.calledWith('https://track-eu.customer.io/api/v2/batch', { batch: operations }));
 });
 
 test('#batch throws when operations is empty', (t) => {


### PR DESCRIPTION
## Summary

Adds `TrackClient.batch(operations)` which POSTs an array of operations to the [v2 batch endpoint](https://customer.io/docs/api/track/#operation/batch). The v2 URL is derived from the existing track root (or a custom `defaults.url`) by swapping `/api/v1` → `/api/v2`, so region selection and custom URL overrides continue to work without additional configuration.

## API

```javascript
cio.batch([
  { type: "person", action: "identify", identifiers: { id: "1" }, attributes: { plan: "pro" } },
  { type: "person", action: "event", identifiers: { id: "1" }, name: "signup" },
]);
```

The `operations` parameter is required and must be a non-empty array; otherwise a `MissingParamError` is thrown. Operation items are passed through as the `batch` field of the request body, so callers are free to shape items per the public API docs without the SDK pinning a schema snapshot.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 156 tests pass, nyc 100% coverage gate holds (branches/lines/functions/statements)
- [x] Constructor tests extended to assert the new `trackV2Root` field for default region, both regions, and custom URL
- [x] `#batch` tests cover the happy path (US), region variant (EU), empty-array rejection, and non-array rejection

Opening as draft pending review of the URL derivation strategy and the permissive `BatchOperation` type.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New optional API surface with input validation only; no changes to existing identify/track flows beyond URL metadata on the client.
> 
> **Overview**
> Adds **`TrackClient.batch(operations)`** to POST a non-empty array of operations to the Track API **`/api/v2/batch`** endpoint, wrapping them as `{ batch: operations }` with permissive `BatchOperation` typing.
> 
> Introduces **`trackV2Root`** (and **`Region.trackV2Url`**) by deriving v2 from the existing v1 track URL—`/api/v1` → `/api/v2` for built-in US/EU regions and custom `defaults.url` when that segment is present; a custom URL without `/api/v1` is used unchanged for both roots.
> 
> README documents usage; tests cover US/EU batch URLs, v2 root construction, and validation when `operations` is missing, empty, or not an array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6077cd1030529f44a95fb16cac010705f4e3a0ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->