### PR TITLE
CDP-6025: add TSDoc to public API + TypeDoc reference site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ coverage.html
 
 .DS_Store
 dist/
+docs/
 
 # Live integration test credentials (never commit)
 test/integration/live.env

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ export * from './lib/regions';
 export * from './lib/types';
 export { CustomerIORequestError, MissingParamError } from './lib/utils';
 export type { ResponseLike } from './lib/utils';
-export type { RetryOptions } from './lib/request';
+export type { RequestDefaults, RetryOptions } from './lib/request';
 export type {
   Identifiers,
   SendEmailRequestOptions,

--- a/index.ts
+++ b/index.ts
@@ -4,8 +4,8 @@ export * from './lib/pipelines';
 export * from './lib/regions';
 export * from './lib/types';
 export { CustomerIORequestError, MissingParamError } from './lib/utils';
+export type { ResponseLike } from './lib/utils';
 export type { RetryOptions } from './lib/request';
-export type { RequestData, PushRequestData, BasicAuth, BearerAuth, RequestAuth } from './lib/request';
 export type {
   Identifiers,
   SendEmailRequestOptions,

--- a/index.ts
+++ b/index.ts
@@ -3,5 +3,19 @@ export * from './lib/api';
 export * from './lib/pipelines';
 export * from './lib/regions';
 export * from './lib/types';
+export { CustomerIORequestError, MissingParamError } from './lib/utils';
 export type { RetryOptions } from './lib/request';
-export { CustomerIORequestError } from './lib/utils';
+export type { RequestData, PushRequestData, BasicAuth, BearerAuth, RequestAuth } from './lib/request';
+export type {
+  Identifiers,
+  SendEmailRequestOptions,
+  SendPushRequestOptions,
+  SendSMSRequestOptions,
+  SendInboxMessageRequestOptions,
+  SendInAppRequestOptions,
+  EmailMessage,
+  PushMessage,
+  SMSMessage,
+  InboxMessage,
+  InAppMessage,
+} from './lib/api/requests';

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -101,7 +101,9 @@ export class APIClient {
   /**
    * @param appKey Your Customer.io App API bearer token.
    * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or {@link RegionEU},
-   *   `url` to point at a custom host, or any `https.RequestOptions` field such as `timeout`.
+   *   `url` to point at a custom host, `timeout` (ms, default `10000`), or any other fetch
+   *   {@link RequestDefaults} field — notably `dispatcher` (an undici `Agent` / `ProxyAgent`) for
+   *   proxies, custom TLS, or connection keep-alive.
    * @throws If `region` is provided and is not a {@link Region} instance.
    */
   constructor(appKey: BearerAuth, defaults: Partial<APIDefaults> = {}) {
@@ -325,7 +327,7 @@ export class APIClient {
    */
   getAttributes(id: string | number, idType: IdentifierType = IdentifierType.Id) {
     if (isEmpty(id)) {
-      throw new MissingParamError('customerId');
+      throw new MissingParamError('id');
     }
 
     if (!isIdentifierType(idType)) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -77,6 +77,9 @@ const filterRecipientsDataForField = (recipients: Recipients, field: BroadcastsA
  * transactional messages, trigger broadcasts, look up customers, and
  * manage exports.
  *
+ * Every method rejects with a {@link CustomerIORequestError} when the API
+ * returns a non-2xx status.
+ *
  * @example
  * ```ts
  * import { APIClient, RegionUS, SendEmailRequest } from 'customerio-node';
@@ -285,7 +288,7 @@ export class APIClient {
    *
    * @param filters Filter expression (segment / attribute / and / or / not).
    * @returns The parsed JSON response body, including the new export's id.
-   * @throws {MissingParamError} If `filters` is empty.
+   * @throws {MissingParamError} If `filters` is `null` or `undefined`.
    */
   createCustomersExport(filters: Filter) {
     if (filters == null) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -18,6 +18,10 @@ type Recipients = Record<string, unknown>;
 
 type BroadcastsAllowedRecipientFieldsKeys = keyof typeof BROADCASTS_ALLOWED_RECIPIENT_FIELDS;
 
+/**
+ * Metric to scope a delivery export to. Pass via the `options.metric` field
+ * of {@link APIClient.createDeliveriesExport}.
+ */
 export enum DeliveryExportMetric {
   Created = 'created',
   Attempted = 'attempted',
@@ -34,11 +38,19 @@ export enum DeliveryExportMetric {
   Undeliverable = 'undeliverable',
 }
 
+/**
+ * Optional filters for {@link APIClient.createDeliveriesExport}.
+ */
 export type DeliveryExportRequestOptions = {
+  /** Inclusive start of the window, as a Unix timestamp (seconds). */
   start?: number;
+  /** Inclusive end of the window, as a Unix timestamp (seconds). */
   end?: number;
+  /** Specific delivery attributes to include in the export. */
   attributes?: string[];
+  /** Filter to a single delivery metric. See {@link DeliveryExportMetric}. */
   metric?: DeliveryExportMetric;
+  /** When `true`, include draft messages. Defaults to `false`. */
   drafts?: boolean;
 };
 
@@ -58,12 +70,37 @@ const filterRecipientsDataForField = (recipients: Recipients, field: BroadcastsA
   }, {});
 };
 
+/**
+ * Client for the Customer.io App API.
+ *
+ * Authenticates with a bearer App API key. Use this client to send
+ * transactional messages, trigger broadcasts, look up customers, and
+ * manage exports.
+ *
+ * @example
+ * ```ts
+ * import { APIClient, RegionUS, SendEmailRequest } from 'customerio-node';
+ *
+ * const api = new APIClient(appKey, { region: RegionUS });
+ * await api.sendEmail(new SendEmailRequest({
+ *   to: 'a@example.com',
+ *   identifiers: { email: 'a@example.com' },
+ *   transactional_message_id: 'welcome',
+ * }));
+ * ```
+ */
 export class APIClient {
   appKey: BearerAuth;
   defaults: APIDefaults;
   request: Request;
   apiRoot: string;
 
+  /**
+   * @param appKey Your Customer.io App API bearer token.
+   * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or {@link RegionEU},
+   *   `url` to point at a custom host, or any `https.RequestOptions` field such as `timeout`.
+   * @throws If `region` is provided and is not a {@link Region} instance.
+   */
   constructor(appKey: BearerAuth, defaults: Partial<APIDefaults> = {}) {
     if (defaults.region && !(defaults.region instanceof Region)) {
       throw new Error('region must be one of Regions.US or Regions.EU');
@@ -79,6 +116,13 @@ export class APIClient {
     this.apiRoot = this.defaults.url ? this.defaults.url : this.defaults.region.apiUrl;
   }
 
+  /**
+   * Send a transactional email.
+   *
+   * @param req A constructed {@link SendEmailRequest} instance.
+   * @returns The parsed JSON response body (includes delivery id).
+   * @throws {Error} If `req` is not a {@link SendEmailRequest} instance.
+   */
   sendEmail(req: SendEmailRequest) {
     if (!(req instanceof SendEmailRequest)) {
       throw new Error('"request" must be an instance of SendEmailRequest');
@@ -87,6 +131,13 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/email`, req.message);
   }
 
+  /**
+   * Send a transactional push notification.
+   *
+   * @param req A constructed {@link SendPushRequest} instance.
+   * @returns The parsed JSON response body.
+   * @throws {Error} If `req` is not a {@link SendPushRequest} instance.
+   */
   sendPush(req: SendPushRequest) {
     if (!(req instanceof SendPushRequest)) {
       throw new Error('"request" must be an instance of SendPushRequest');
@@ -95,6 +146,13 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/push`, req.message);
   }
 
+  /**
+   * Send a transactional SMS.
+   *
+   * @param req A constructed {@link SendSMSRequest} instance.
+   * @returns The parsed JSON response body.
+   * @throws {Error} If `req` is not a {@link SendSMSRequest} instance.
+   */
   sendSMS(req: SendSMSRequest) {
     if (!(req instanceof SendSMSRequest)) {
       throw new Error('"request" must be an instance of SendSMSRequest');
@@ -103,6 +161,13 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/sms`, req.message);
   }
 
+  /**
+   * Send a transactional inbox message.
+   *
+   * @param req A constructed {@link SendInboxMessageRequest} instance.
+   * @returns The parsed JSON response body.
+   * @throws {Error} If `req` is not a {@link SendInboxMessageRequest} instance.
+   */
   sendInboxMessage(req: SendInboxMessageRequest) {
     if (!(req instanceof SendInboxMessageRequest)) {
       throw new Error('"request" must be an instance of SendInboxMessageRequest');
@@ -111,6 +176,13 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/inbox_message`, req.message);
   }
 
+  /**
+   * Send a transactional in-app message.
+   *
+   * @param req A constructed {@link SendInAppRequest} instance.
+   * @returns The parsed JSON response body.
+   * @throws {Error} If `req` is not a {@link SendInAppRequest} instance.
+   */
   sendInApp(req: SendInAppRequest) {
     if (!(req instanceof SendInAppRequest)) {
       throw new Error('"request" must be an instance of SendInAppRequest');
@@ -119,6 +191,13 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/send/in_app`, req.message);
   }
 
+  /**
+   * Look up all people in your workspace with a matching email address.
+   *
+   * @param email Full email address. Will be URL-encoded.
+   * @returns The parsed JSON response body (`{ results: [...] }`).
+   * @throws {Error} If `email` is not a non-empty string.
+   */
   getCustomersByEmail(email: string) {
     if (typeof email !== 'string' || isEmpty(email)) {
       throw new Error('"email" must be a string');
@@ -127,6 +206,21 @@ export class APIClient {
     return this.request.get(`${this.apiRoot}/customers?email=${encodeURIComponent(email)}`);
   }
 
+  /**
+   * Trigger an API-triggered broadcast (campaign).
+   *
+   * `recipients` may contain one of the special fields `ids`, `emails`,
+   * `per_user_data`, or `data_file_url` (with associated `*_ignore_missing` /
+   * `email_add_duplicates` flags); when present, that field's allowed
+   * companions are forwarded and any other recipients fields are ignored.
+   * Otherwise the entire `recipients` object is forwarded verbatim alongside
+   * `data` (use this for segment-based recipients).
+   *
+   * @param broadcastId The broadcast (campaign) id.
+   * @param data Liquid `data` payload made available to the broadcast template.
+   * @param recipients Recipient selector. See above.
+   * @returns The parsed JSON response body.
+   */
   triggerBroadcast(broadcastId: string | number, data: RequestData, recipients: Recipients) {
     let payload = {};
     let customRecipientField = (
@@ -145,10 +239,22 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers`, payload);
   }
 
+  /**
+   * List all exports in your workspace.
+   *
+   * @returns The parsed JSON response body (`{ exports: [...] }`).
+   */
   listExports() {
     return this.request.get(`${this.apiRoot}/exports`);
   }
 
+  /**
+   * Get metadata for a specific export, including its status.
+   *
+   * @param id The export id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `id` is empty.
+   */
   getExport(id: string | number) {
     if (isEmpty(id)) {
       throw new MissingParamError('id');
@@ -157,6 +263,15 @@ export class APIClient {
     return this.request.get(`${this.apiRoot}/exports/${encodeURIComponent(id)}`);
   }
 
+  /**
+   * Get a time-limited download URL for an export.
+   *
+   * Only meaningful once {@link APIClient.getExport} reports the export as ready.
+   *
+   * @param id The export id.
+   * @returns The parsed JSON response body (`{ link: "..." }`).
+   * @throws {MissingParamError} If `id` is empty.
+   */
   downloadExport(id: string | number) {
     if (isEmpty(id)) {
       throw new MissingParamError('id');
@@ -165,6 +280,13 @@ export class APIClient {
     return this.request.get(`${this.apiRoot}/exports/${encodeURIComponent(id)}/download`);
   }
 
+  /**
+   * Start an export of people matching a filter.
+   *
+   * @param filters Filter expression (segment / attribute / and / or / not).
+   * @returns The parsed JSON response body, including the new export's id.
+   * @throws {MissingParamError} If `filters` is empty.
+   */
   createCustomersExport(filters: Filter) {
     if (filters == null) {
       throw new MissingParamError('filters');
@@ -173,6 +295,14 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/exports/customers`, { filters });
   }
 
+  /**
+   * Start an export of delivery telemetry for a given newsletter.
+   *
+   * @param newsletterId The newsletter id whose deliveries should be exported.
+   * @param options Optional filters — see {@link DeliveryExportRequestOptions}.
+   * @returns The parsed JSON response body, including the new export's id.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
   createDeliveriesExport(newsletterId: number, options?: DeliveryExportRequestOptions) {
     if (isEmpty(newsletterId)) {
       throw new MissingParamError('newsletterId');
@@ -181,6 +311,15 @@ export class APIClient {
     return this.request.post(`${this.apiRoot}/exports/deliveries`, { newsletter_id: newsletterId, ...options });
   }
 
+  /**
+   * Get a person's attributes by identifier.
+   *
+   * @param id The person's identifier value.
+   * @param idType Which identifier kind to look up by. Defaults to {@link IdentifierType.Id}.
+   * @returns The parsed JSON response body (`{ customer: {...} }`).
+   * @throws {MissingParamError} If `id` is empty.
+   * @throws {Error} If `idType` is not a valid {@link IdentifierType}.
+   */
   getAttributes(id: string | number, idType: IdentifierType = IdentifierType.Id) {
     if (isEmpty(id)) {
       throw new MissingParamError('customerId');

--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -67,7 +67,6 @@ const EMAIL_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendEmailRequestOptionalOptions>;
 
-
 /**
  * Builder for a transactional email request. Pass an instance to
  * {@link APIClient.sendEmail}.
@@ -207,7 +206,6 @@ const PUSH_OPTIONAL_KEYS = [
   'custom_data',
 ] as const satisfies ReadonlyArray<keyof SendPushRequestOptionalOptions>;
 
-
 /**
  * Builder for a transactional push notification request. Pass an instance to
  * {@link APIClient.sendPush}.
@@ -267,7 +265,6 @@ const SMS_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendSMSRequestOptionalOptions>;
 
-
 /**
  * Builder for a transactional SMS request. Pass an instance to {@link APIClient.sendSMS}.
  */
@@ -314,7 +311,6 @@ const INBOX_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendInboxMessageRequestOptionalOptions>;
 
-
 /**
  * Builder for a transactional inbox message request. Pass an instance to
  * {@link APIClient.sendInboxMessage}.
@@ -360,7 +356,6 @@ const IN_APP_OPTIONAL_KEYS = [
   'send_at',
   'language',
 ] as const satisfies ReadonlyArray<keyof SendInAppRequestOptionalOptions>;
-
 
 /**
  * Builder for a transactional in-app message request. Pass an instance to

--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -67,7 +67,28 @@ const EMAIL_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendEmailRequestOptionalOptions>;
 
+
+/**
+ * Builder for a transactional email request. Pass an instance to
+ * {@link APIClient.sendEmail}.
+ *
+ * Provide either a `transactional_message_id` (to use a Customer.io-managed
+ * template) **or** inline `body`, `subject`, and `from` fields.
+ *
+ * @example
+ * ```ts
+ * const req = new SendEmailRequest({
+ *   to: 'a@example.com',
+ *   identifiers: { email: 'a@example.com' },
+ *   transactional_message_id: 'welcome',
+ *   message_data: { first_name: 'Alex' },
+ * });
+ * req.attach('invoice.pdf', pdfBuffer);
+ * await api.sendEmail(req);
+ * ```
+ */
 export class SendEmailRequest {
+  /** The fully-shaped message payload sent to the API. */
   message: EmailMessage;
 
   static [Symbol.hasInstance](instance: unknown): instance is SendEmailRequest {
@@ -100,6 +121,18 @@ export class SendEmailRequest {
     }
   }
 
+  /**
+   * Attach a file to the email.
+   *
+   * By default the data is base64-encoded for you. Pass `{ encode: false }` if
+   * `data` is already base64.
+   *
+   * @param name Filename (and attachment key — must be unique on this request).
+   * @param data File contents. Any `Buffer.from`-compatible value when `encode` is `true`;
+   *   a base64 string when `encode` is `false`.
+   * @param options `encode` defaults to `true`.
+   * @throws {Error} If an attachment with `name` already exists on this request.
+   */
   // Use `any` for data here, because union types and overloads in Typescript
   // don't work well together for `Buffer.from`.
   attach(name: string, data: any, { encode = true } = {}) {
@@ -174,6 +207,14 @@ const PUSH_OPTIONAL_KEYS = [
   'custom_data',
 ] as const satisfies ReadonlyArray<keyof SendPushRequestOptionalOptions>;
 
+
+/**
+ * Builder for a transactional push notification request. Pass an instance to
+ * {@link APIClient.sendPush}.
+ *
+ * Either supply a `transactional_message_id` to use a Customer.io template,
+ * or include a `custom_payload` for a fully-custom message.
+ */
 export class SendPushRequest {
   message: PushMessage;
 
@@ -226,6 +267,10 @@ const SMS_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendSMSRequestOptionalOptions>;
 
+
+/**
+ * Builder for a transactional SMS request. Pass an instance to {@link APIClient.sendSMS}.
+ */
 export class SendSMSRequest {
   message: SMSMessage;
 
@@ -269,6 +314,11 @@ const INBOX_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendInboxMessageRequestOptionalOptions>;
 
+
+/**
+ * Builder for a transactional inbox message request. Pass an instance to
+ * {@link APIClient.sendInboxMessage}.
+ */
 export class SendInboxMessageRequest {
   message: InboxMessage;
 
@@ -311,6 +361,11 @@ const IN_APP_OPTIONAL_KEYS = [
   'language',
 ] as const satisfies ReadonlyArray<keyof SendInAppRequestOptionalOptions>;
 
+
+/**
+ * Builder for a transactional in-app message request. Pass an instance to
+ * {@link APIClient.sendInApp}.
+ */
 export class SendInAppRequest {
   message: InAppMessage;
 

--- a/lib/pipelines.ts
+++ b/lib/pipelines.ts
@@ -74,7 +74,8 @@ export class PipelinesClient {
    * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or
    *   {@link RegionEU}, `url` to point at a custom host, `strictMode` to have the API
    *   validate payloads and return real HTTP errors, or `defaultContext` to merge a
-   *   base `context` under every call. Accepts any `https.RequestOptions` field too.
+   *   base `context` under every call. Accepts any fetch {@link RequestDefaults} field too
+   *   (e.g. `timeout`, or `dispatcher` for proxies / custom TLS / keep-alive).
    * @throws {MissingParamError} If `writeKey` is empty.
    * @throws {Error} If `region` is provided and is not a {@link Region} instance.
    */

--- a/lib/pipelines.ts
+++ b/lib/pipelines.ts
@@ -39,6 +39,29 @@ export type PipelinesDefaults = RequestDefaults & {
   retry?: Partial<RetryOptions>;
 };
 
+/**
+ * Client for the Customer.io Pipelines (Data Pipelines) API.
+ *
+ * Authenticates with a Data Pipelines source write key. Use this client to send
+ * Segment-compatible identify/track/page/screen/group/alias events, one at a
+ * time or batched. Payloads use camelCase (`userId`, `anonymousId`, `groupId`,
+ * `previousId`), matching the Pipelines wire format.
+ *
+ * `messageId`, `timestamp`, and `context.library` are auto-filled on every call
+ * when you don't supply them; per-call values always win.
+ *
+ * Every method rejects with a {@link CustomerIORequestError} when the API
+ * returns a non-2xx status.
+ *
+ * @example
+ * ```ts
+ * import { PipelinesClient, RegionUS } from 'customerio-node';
+ *
+ * const cdp = new PipelinesClient(writeKey, { region: RegionUS });
+ * await cdp.identify({ userId: '123', traits: { email: 'a@example.com' } });
+ * await cdp.track({ userId: '123', event: 'Signed Up' });
+ * ```
+ */
 export class PipelinesClient {
   writeKey: string;
   defaults: PipelinesDefaults;
@@ -46,6 +69,15 @@ export class PipelinesClient {
   pipelinesRoot: string;
   private readonly autoContext: PipelinesContext;
 
+  /**
+   * @param writeKey Your Data Pipelines source write key (Data Pipelines -> Sources).
+   * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or
+   *   {@link RegionEU}, `url` to point at a custom host, `strictMode` to have the API
+   *   validate payloads and return real HTTP errors, or `defaultContext` to merge a
+   *   base `context` under every call. Accepts any `https.RequestOptions` field too.
+   * @throws {MissingParamError} If `writeKey` is empty.
+   * @throws {Error} If `region` is provided and is not a {@link Region} instance.
+   */
   constructor(writeKey: string, defaults: Partial<PipelinesDefaults> = {}) {
     if (isEmpty(writeKey)) {
       throw new MissingParamError('writeKey');
@@ -88,6 +120,14 @@ export class PipelinesClient {
     };
   }
 
+  /**
+   * Identify a person, creating or updating their traits.
+   *
+   * @param payload Identify payload. Must include `userId` or `anonymousId`;
+   *   `traits` carries the person's attributes.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If neither `userId` nor `anonymousId` is present.
+   */
   identify(payload: IdentifyPayload) {
     if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
       throw new MissingParamError('userId or anonymousId');
@@ -95,6 +135,14 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/identify`, this.envelope(payload));
   }
 
+  /**
+   * Record an event for a person.
+   *
+   * @param payload Track payload. Must include `userId` or `anonymousId` and a
+   *   non-empty `event` name; `properties` carries event attributes.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `userId`/`anonymousId` or `event` is missing.
+   */
   track(payload: TrackPayload) {
     if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
       throw new MissingParamError('userId or anonymousId');
@@ -105,6 +153,14 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/track`, this.envelope(payload));
   }
 
+  /**
+   * Record a page view (web) for a person.
+   *
+   * @param payload Page payload. Must include `userId` or `anonymousId`;
+   *   optional `name`, `category`, and `properties`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If neither `userId` nor `anonymousId` is present.
+   */
   page(payload: PagePayload) {
     if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
       throw new MissingParamError('userId or anonymousId');
@@ -112,6 +168,14 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/page`, this.envelope(payload));
   }
 
+  /**
+   * Record a screen view (mobile) for a person.
+   *
+   * @param payload Screen payload. Must include `userId` or `anonymousId`;
+   *   optional `name`, `category`, and `properties`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If neither `userId` nor `anonymousId` is present.
+   */
   screen(payload: ScreenPayload) {
     if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
       throw new MissingParamError('userId or anonymousId');
@@ -119,6 +183,14 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/screen`, this.envelope(payload));
   }
 
+  /**
+   * Associate a person with a group (e.g. an account or organization).
+   *
+   * @param payload Group payload. Must include `userId` or `anonymousId` and a
+   *   non-empty `groupId`; `traits` carries group attributes.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `userId`/`anonymousId` or `groupId` is missing.
+   */
   group(payload: GroupPayload) {
     if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
       throw new MissingParamError('userId or anonymousId');
@@ -129,6 +201,13 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/group`, this.envelope(payload));
   }
 
+  /**
+   * Merge two identities by aliasing a previous id to a user id.
+   *
+   * @param payload Alias payload. Must include both `userId` and `previousId`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `userId` or `previousId` is missing.
+   */
   alias(payload: AliasPayload) {
     if (isEmpty(payload?.userId)) {
       throw new MissingParamError('userId');
@@ -139,6 +218,15 @@ export class PipelinesClient {
     return this.request.post(`${this.pipelinesRoot}/alias`, this.envelope(payload));
   }
 
+  /**
+   * Send multiple events in a single request. Each item carries a `type`
+   * discriminator (`identify`, `track`, `page`, `screen`, `group`, or `alias`)
+   * and is enveloped (auto-filled `messageId`/`timestamp`/`context`) individually.
+   *
+   * @param items A non-empty array of {@link BatchItem} entries.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `items` is not a non-empty array.
+   */
   batch(items: BatchItem[]) {
     if (!Array.isArray(items) || items.length === 0) {
       throw new MissingParamError('items');

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -1,9 +1,20 @@
 const REGION_BRAND = Symbol.for('customerio-node.Region');
 
+/**
+ * A Customer.io data region. Selects the base URLs used by {@link TrackClient}
+ * and {@link APIClient}.
+ *
+ * Use the pre-defined {@link RegionUS} and {@link RegionEU} constants rather
+ * than constructing a `Region` directly.
+ */
 export class Region {
+  /** Base URL for the Track API (basic-auth, site-id/api-key). */
   readonly trackUrl: string;
+  /** Base URL for the Track API v2 (batch endpoint). Derived from {@link trackUrl}. */
   readonly trackV2Url: string;
+  /** Base URL for the App API (bearer-auth, app key). */
   readonly apiUrl: string;
+  /** Base URL for the Pipelines (CDP) API. */
   readonly pipelinesUrl: string;
 
   static [Symbol.hasInstance](instance: unknown): instance is Region {
@@ -19,11 +30,14 @@ export class Region {
   }
 }
 
+/** US data region. Default when no region is specified. */
 export const RegionUS = new Region(
   'https://track.customer.io/api/v1',
   'https://api.customer.io/v1',
   'https://cdp.customer.io/v1',
 );
+
+/** EU data region. Use this if your Customer.io workspace is hosted in the EU. */
 export const RegionEU = new Region(
   'https://track-eu.customer.io/api/v1',
   'https://api-eu.customer.io/v1',

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -8,6 +8,21 @@ type TrackDefaults = RequestDefaults & { region: Region; url?: string; retry?: P
 
 export type BatchOperation = Record<string, any>;
 
+/**
+ * Client for the Customer.io Track API.
+ *
+ * Authenticates with a site id + API key (basic auth). Use this client to
+ * identify people, track events, manage devices, and merge profiles.
+ *
+ * @example
+ * ```ts
+ * import { TrackClient, RegionUS } from 'customerio-node';
+ *
+ * const cio = new TrackClient(siteId, apiKey, { region: RegionUS });
+ * await cio.identify('123', { email: 'a@example.com', plan: 'pro' });
+ * await cio.track('123', { name: 'signup' });
+ * ```
+ */
 export class TrackClient {
   siteid: BasicAuth['siteid'];
   apikey: BasicAuth['apikey'];
@@ -16,6 +31,14 @@ export class TrackClient {
   trackRoot: string;
   trackV2Root: string;
 
+  /**
+   * @param siteid Your Customer.io workspace site id.
+   * @param apikey Your Customer.io Track API key.
+   * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or {@link RegionEU},
+   *   `url` to point at a custom host (e.g. a mock server), or any `https.RequestOptions` field
+   *   such as `timeout` (default `10000`).
+   * @throws If `region` is provided and is not a {@link Region} instance.
+   */
   constructor(siteid: BasicAuth['siteid'], apikey: BasicAuth['apikey'], defaults: Partial<TrackDefaults> = {}) {
     if (defaults.region && !(defaults.region instanceof Region)) {
       throw new Error('region must be one of Regions.US or Regions.EU');
@@ -35,6 +58,19 @@ export class TrackClient {
       : this.defaults.region.trackV2Url;
   }
 
+  /**
+   * Create or update a person.
+   *
+   * To update an existing person's identifier (e.g. change their `id` or `email`),
+   * pass the `cio_id` prefixed with `cio_` as `customerId`.
+   *
+   * @param customerId The person's unique identifier (id, email, or `cio_<cio_id>`).
+   * @param data Attributes to set on the person. `email` is required if you intend to
+   *   send email messages; `created_at` is required for time-based segmentation.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` is empty.
+   * @throws {CustomerIORequestError} On non-2xx API responses.
+   */
   identify(customerId: string | number, data: RequestData = {}) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -43,6 +79,16 @@ export class TrackClient {
     return this.request.put(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}`, data);
   }
 
+  /**
+   * Permanently delete a person.
+   *
+   * This does not suppress the person — they can be re-added later. To prevent
+   * re-adding, use {@link TrackClient.suppress} instead.
+   *
+   * @param customerId The person's unique identifier.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` is empty.
+   */
   destroy(customerId: string | number) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -51,6 +97,14 @@ export class TrackClient {
     return this.request.destroy(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}`);
   }
 
+  /**
+   * Suppress a person. Suppressed people are deleted and cannot be re-added by
+   * subsequent `identify` calls. Pair with {@link TrackClient.unsuppress} to reverse.
+   *
+   * @param customerId The person's unique identifier.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` is empty.
+   */
   suppress(customerId: string | number) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -59,6 +113,13 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/suppress`);
   }
 
+  /**
+   * Unsuppress a previously suppressed person.
+   *
+   * @param customerId The person's unique identifier.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` is empty.
+   */
   unsuppress(customerId: string | number) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -67,6 +128,15 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/unsuppress`);
   }
 
+  /**
+   * Record an event for a known person.
+   *
+   * @param customerId The person's unique identifier.
+   * @param data Event payload. Must include a `name` string. Optionally include `data`
+   *   (object of event attributes) and `type` to differentiate event vs. page events.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` or `data.name` is empty.
+   */
   track(customerId: string | number, data: RequestData = {}) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -79,6 +149,22 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/customers/${encodeURIComponent(customerId)}/events`, data);
   }
 
+  /**
+   * Record an event for an anonymous (not-yet-identified) person.
+   *
+   * Anonymous events cannot trigger campaigns directly, but if event merging
+   * is enabled and you later `identify` the person with a matching
+   * `anonymous_id` attribute, prior anonymous events will be associated
+   * with the profile. Events associated within 72 hours can trigger campaigns.
+   *
+   * Pass an empty string for `anonymousId` to send an anonymous invite event
+   * (requires a `recipient` attribute in `data`).
+   *
+   * @param anonymousId Identifier for the anonymous person, or `''` for an invite event.
+   * @param data Event payload. Must include a `name` string.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `data.name` is empty.
+   */
   trackAnonymous(anonymousId: string | number, data: RequestData = {}) {
     if (isEmpty(data.name)) {
       throw new MissingParamError('data.name');
@@ -93,6 +179,14 @@ export class TrackClient {
     return this.request.post(`${this.trackRoot}/events`, payload);
   }
 
+  /**
+   * Record a page view event for a known person.
+   *
+   * @param customerId The person's unique identifier.
+   * @param path The page URL or path being viewed.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` or `path` is empty.
+   */
   trackPageView(customerId: string | number, path: string) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -108,10 +202,30 @@ export class TrackClient {
     });
   }
 
+  /**
+   * Report a push notification lifecycle event (delivered, opened, converted).
+   *
+   * Used by integrations that want to feed delivery telemetry back to Customer.io
+   * for analytics and campaign optimization.
+   *
+   * @param data Push event payload (delivery_id, device_id, event, timestamp).
+   * @returns The parsed JSON response body.
+   */
   trackPush(data: PushRequestData = {}) {
     return this.request.post(`${this.trackRoot}/push/events`, data);
   }
 
+  /**
+   * Register a device for push delivery to a person.
+   *
+   * @param customerId The person's unique identifier.
+   * @param device_id The platform-issued device/push token (e.g. APNs token, FCM token).
+   * @param platform Device platform — typically `"ios"` or `"android"`.
+   * @param data Optional device metadata. `last_used` (unix timestamp) is treated specially;
+   *   any other keys are stored as device attributes.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId`, `device_id`, or `platform` is empty.
+   */
   addDevice(customerId: string | number, device_id: string, platform: string, data: Record<string, any> = {}) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -137,6 +251,14 @@ export class TrackClient {
     });
   }
 
+  /**
+   * Remove a device from a person.
+   *
+   * @param customerId The person's unique identifier.
+   * @param deviceToken The device/push token to remove.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` or `deviceToken` is empty.
+   */
   deleteDevice(customerId: string | number, deviceToken: string | number) {
     if (isEmpty(customerId)) {
       throw new MissingParamError('customerId');
@@ -151,6 +273,16 @@ export class TrackClient {
     );
   }
 
+  /**
+   * Send a batch of Track API operations in a single request to the v2 batch endpoint.
+   *
+   * Each operation is a self-describing object (e.g. an identify, track, or
+   * delete payload). Use this to reduce request overhead for high-volume work.
+   *
+   * @param operations A non-empty array of batch operation objects.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `operations` is not a non-empty array.
+   */
   batch(operations: BatchOperation[]) {
     if (!Array.isArray(operations) || operations.length === 0) {
       throw new MissingParamError('operations');
@@ -159,6 +291,21 @@ export class TrackClient {
     return this.request.post(`${this.trackV2Root}/batch`, { batch: operations });
   }
 
+  /**
+   * Merge two people. The secondary profile is permanently deleted and its
+   * attributes/events are merged into the primary.
+   *
+   * The identifier types are independent: you can merge by `email` into a
+   * profile identified by `id`, and so on.
+   *
+   * @param primaryIdType Type of identifier for the surviving profile.
+   * @param primaryId Identifier value for the surviving profile.
+   * @param secondaryIdType Type of identifier for the profile to be merged in.
+   * @param secondaryId Identifier value for the profile to be merged in.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If either `primaryId` or `secondaryId` is empty.
+   * @throws {Error} If either identifier type is not one of {@link IdentifierType}.
+   */
   mergeCustomers(
     primaryIdType: IdentifierType,
     primaryId: string | number,

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -14,6 +14,9 @@ export type BatchOperation = Record<string, any>;
  * Authenticates with a site id + API key (basic auth). Use this client to
  * identify people, track events, manage devices, and merge profiles.
  *
+ * Every method rejects with a {@link CustomerIORequestError} when the API
+ * returns a non-2xx status.
+ *
  * @example
  * ```ts
  * import { TrackClient, RegionUS } from 'customerio-node';
@@ -69,7 +72,6 @@ export class TrackClient {
    *   send email messages; `created_at` is required for time-based segmentation.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `customerId` is empty.
-   * @throws {CustomerIORequestError} On non-2xx API responses.
    */
   identify(customerId: string | number, data: RequestData = {}) {
     if (isEmpty(customerId)) {

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -38,8 +38,9 @@ export class TrackClient {
    * @param siteid Your Customer.io workspace site id.
    * @param apikey Your Customer.io Track API key.
    * @param defaults Optional overrides. Use `region` to select {@link RegionUS} or {@link RegionEU},
-   *   `url` to point at a custom host (e.g. a mock server), or any `https.RequestOptions` field
-   *   such as `timeout` (default `10000`).
+   *   `url` to point at a custom host (e.g. a mock server), `timeout` (ms, default `10000`), or any
+   *   other fetch {@link RequestDefaults} field — notably `dispatcher` (an undici `Agent` /
+   *   `ProxyAgent`) for proxies, custom TLS, or connection keep-alive.
    * @throws If `region` is provided and is not a {@link Region} instance.
    */
   constructor(siteid: BasicAuth['siteid'], apikey: BasicAuth['apikey'], defaults: Partial<TrackDefaults> = {}) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,37 +1,55 @@
+/**
+ * The three identifier kinds Customer.io accepts for a person.
+ *
+ * - `Id` — your application's user id
+ * - `Email` — the person's email address
+ * - `CioId` — Customer.io's internal stable id (prefix with `cio_` when used as a path segment)
+ */
 export enum IdentifierType {
   Id = 'id',
   Email = 'email',
   CioId = 'cio_id',
 }
 
+/** Comparison operators supported in {@link AttributeFilter}. */
 export enum FilterOperator {
   Eq = 'eq',
   Exists = 'exists',
 }
 
+/** Filter matching everyone in a given segment. */
 export type SegmentFilter = {
   id: number;
 };
 
+/** Filter matching people whose attribute satisfies an operator/value. */
 export type AttributeFilter = {
   field: string;
   operator: FilterOperator;
   value?: string;
 };
 
+/** Negation of either a segment or attribute filter. */
 export type NotFilter = {
   segment?: SegmentFilter;
   attribute?: AttributeFilter;
 };
 
+/** Union of the leaf filter shapes that compose larger boolean filters. */
 export type FilterObject = SegmentFilter | AttributeFilter | NotFilter;
 
+/** All sub-filters must match. */
 export type AndFilter = {
   and: FilterObject[];
 };
 
+/** At least one sub-filter must match. */
 export type OrFilter = {
   or: FilterObject[];
 };
 
+/**
+ * Top-level filter expression. Compose with {@link AndFilter} / {@link OrFilter}
+ * and nest {@link SegmentFilter}, {@link AttributeFilter}, or {@link NotFilter}.
+ */
 export type Filter = AndFilter | OrFilter;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -30,6 +30,13 @@ export interface ResponseLike {
  * raw status code, response, and body are exposed for programmatic handling
  * (e.g. retry on 5xx, ignore on 404).
  *
+ * @remarks
+ * This is only thrown for HTTP responses with a non-2xx status. Transport-level
+ * failures (DNS, connection reset, refused) and timeouts are surfaced as the
+ * native `fetch` errors — `TypeError('fetch failed')` (with the underlying
+ * cause on `.cause`) and `DOMException('TimeoutError')` respectively — not as a
+ * `CustomerIORequestError`.
+ *
  * @example
  * ```ts
  * try {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,11 +1,13 @@
 import { IdentifierType } from '../lib/types';
 
+/** Returns `true` for `null`, `undefined`, an empty/whitespace string, or a non-finite number. */
 export const isEmpty = (value: string | number | null | undefined) => {
   if (value === null || value === undefined) return true;
   if (typeof value === 'string') return value.trim() === '';
   return !Number.isFinite(value);
 };
 
+/** Returns `true` if `value` is one of the {@link IdentifierType} enum values. */
 export const isIdentifierType = (value: unknown) => {
   return Object.values(IdentifierType).includes(value as IdentifierType);
 };
@@ -21,9 +23,32 @@ export interface ResponseLike {
   ok: boolean;
 }
 
+/**
+ * Thrown when the Customer.io API responds with a non-2xx status.
+ *
+ * The error message is derived from the API response body when possible. The
+ * raw status code, response, and body are exposed for programmatic handling
+ * (e.g. retry on 5xx, ignore on 404).
+ *
+ * @example
+ * ```ts
+ * try {
+ *   await cio.identify('123', { email: 'a@example.com' });
+ * } catch (err) {
+ *   if (err instanceof CustomerIORequestError && err.statusCode === 404) {
+ *     // customer not found, fall through
+ *   } else {
+ *     throw err;
+ *   }
+ * }
+ * ```
+ */
 export class CustomerIORequestError extends Error {
+  /** HTTP status code returned by the API. */
   statusCode: number;
+  /** Portable response metadata ({@link ResponseLike}: status, lowercased headers, `ok`). */
   response: ResponseLike;
+  /** The raw response body as a string. May be empty. */
   body: string;
 
   static composeMessage(json: Record<string, any> | null): string {
@@ -63,6 +88,11 @@ export function pickDefined<T extends Record<string, unknown>>(source: T, keys: 
   return result;
 }
 
+/**
+ * Thrown synchronously by SDK methods when a required parameter is missing.
+ *
+ * The `message` is always `"<paramName> is required"`.
+ */
 export class MissingParamError extends Error {
   constructor(param: string) {
     super(`${param} is required`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "prettier": "^3.8.3",
         "sinon": "^19.0.5",
         "ts-node": "^10.9.1",
+        "typedoc": "^0.28.0",
         "typescript": "^6.0.3",
         "uuid": "^11.0.0"
       },
@@ -432,6 +433,20 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
+    "node_modules/@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -814,6 +829,55 @@
         }
       }
     },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -910,6 +974,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -942,6 +1016,13 @@
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
       "dev": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/uuid": {
       "version": "10.0.0",
@@ -2221,6 +2302,19 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -3395,6 +3489,26 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -3747,6 +3861,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -3779,6 +3900,41 @@
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
     },
     "node_modules/matcher": {
       "version": "5.0.0",
@@ -3818,6 +3974,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/memoize": {
       "version": "10.2.0",
@@ -4537,6 +4700,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5247,6 +5420,30 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      },
+      "bin": {
+        "typedoc": "bin/typedoc"
+      },
+      "engines": {
+        "node": ">= 18",
+        "pnpm": ">= 10"
+      },
+      "peerDependencies": {
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -5260,6 +5457,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
@@ -5858,6 +6062,19 @@
         "levn": "^0.4.1"
       }
     },
+    "@gerrit0/mini-shiki": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.23.0.tgz",
+      "integrity": "sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/engine-oniguruma": "^3.23.0",
+        "@shikijs/langs": "^3.23.0",
+        "@shikijs/themes": "^3.23.0",
+        "@shikijs/types": "^3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
     "@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -6120,6 +6337,50 @@
         "picomatch": "^4.0.2"
       }
     },
+    "@shikijs/engine-oniguruma": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.23.0.tgz",
+      "integrity": "sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.23.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "@shikijs/langs": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.23.0.tgz",
+      "integrity": "sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "@shikijs/themes": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.23.0.tgz",
+      "integrity": "sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==",
+      "dev": true,
+      "requires": {
+        "@shikijs/types": "3.23.0"
+      }
+    },
+    "@shikijs/types": {
+      "version": "3.23.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.23.0.tgz",
+      "integrity": "sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==",
+      "dev": true,
+      "requires": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true
+    },
     "@sindresorhus/merge-streams": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
@@ -6198,6 +6459,15 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true
     },
+    "@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "requires": {
+        "@types/unist": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -6226,6 +6496,12 @@
       "version": "8.1.2",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.2.tgz",
       "integrity": "sha512-9GcLXF0/v3t80caGs5p2rRfkB+a8VBGLJZVih6CNFkx8IZ994wiKKLSRs9nuFwk1HevWs/1mnUmkApGrSGsShA==",
+      "dev": true
+    },
+    "@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "dev": true
     },
     "@types/uuid": {
@@ -7040,6 +7316,12 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "dev": true
+    },
     "environment": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
@@ -7814,6 +8096,15 @@
         "type-check": "~0.4.0"
       }
     },
+    "linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "dev": true,
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "lint-staged": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
@@ -8038,6 +8329,12 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true
     },
+    "lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "dev": true
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -8060,6 +8357,28 @@
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true
+    },
+    "markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "dev": true,
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        }
+      }
     },
     "matcher": {
       "version": "5.0.0",
@@ -8086,6 +8405,12 @@
       "requires": {
         "blueimp-md5": "^2.10.0"
       }
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+      "dev": true
     },
     "memoize": {
       "version": "10.2.0",
@@ -8560,6 +8885,12 @@
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "dev": true
     },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -9014,10 +9345,29 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typedoc": {
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
+      "dev": true,
+      "requires": {
+        "@gerrit0/mini-shiki": "^3.23.0",
+        "lunr": "^2.3.9",
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
+      }
+    },
     "typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
       "dev": true
     },
     "undici-types": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "prettier": "^3.8.3",
     "sinon": "^19.0.5",
     "ts-node": "^10.9.1",
+    "typedoc": "^0.28.0",
     "typescript": "^6.0.3",
     "uuid": "^11.0.0"
   },
@@ -103,6 +104,7 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
+    "docs": "typedoc",
     "prepublishOnly": "npm run build",
     "prepare": "husky",
     "version": "node scripts/sync-version.js && git add lib/version.ts"

--- a/test/api.ts
+++ b/test/api.ts
@@ -487,10 +487,10 @@ test('#createDeliveriesExport: fails without id', (t) => {
   t.falsy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/exports/deliveries`));
 });
 
-test('#getAttributes: fails without customerId', (t) => {
+test('#getAttributes: fails without id', (t) => {
   sinon.stub(t.context.client.request, 'get');
   t.throws(() => (t.context.client.getAttributes as any)(), {
-    message: 'customerId is required',
+    message: 'id is required',
   });
   t.falsy(
     (t.context.client.request.get as SinonStub).calledWith(`${RegionUS.apiUrl}/customers/1/attributes?id_type=id`),

--- a/typedoc.json
+++ b/typedoc.json
@@ -28,6 +28,8 @@
     "SendInAppRequestRequiredOptions",
     "SendInAppRequestOptionalOptions",
     "PipelinesIdentifier",
+    "RequestData",
+    "PushRequestData",
     "default"
   ]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["index.ts"],
+  "out": "docs",
+  "name": "customerio-node",
+  "readme": "README.md",
+  "excludePrivate": true,
+  "excludeInternal": true,
+  "excludeExternals": true,
+  "githubPages": false,
+  "categorizeByGroup": true,
+  "sort": ["source-order"],
+  "navigation": {
+    "includeCategories": true
+  }
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -12,5 +12,22 @@
   "sort": ["source-order"],
   "navigation": {
     "includeCategories": true
-  }
+  },
+  "intentionallyNotExported": [
+    "APIDefaults",
+    "TrackDefaults",
+    "Recipients",
+    "SendPushRequestWithCustomPayload",
+    "SendPushRequestWithoutCustomPayload",
+    "SendEmailRequestWithTemplate",
+    "SendEmailRequestWithoutTemplate",
+    "SendSMSRequestRequiredOptions",
+    "SendSMSRequestOptionalOptions",
+    "SendInboxMessageRequestRequiredOptions",
+    "SendInboxMessageRequestOptionalOptions",
+    "SendInAppRequestRequiredOptions",
+    "SendInAppRequestOptionalOptions",
+    "PipelinesIdentifier",
+    "default"
+  ]
 }


### PR DESCRIPTION
## Summary

Every public method on \`TrackClient\` and \`APIClient\`, every \`Send*Request\` builder, the \`Region\` exports, the \`IdentifierType\` / \`Filter\` types, and the error classes now carry TSDoc with \`@param\` / \`@returns\` / \`@throws\` and short usage examples where helpful. IDE hover and autocomplete pick these up automatically — no more empty hover tooltips.

Also wires up [TypeDoc](https://typedoc.org/) so the same comments power a static API reference site:

\`\`\`sh
npm run docs   # generates docs/ from index.ts
\`\`\`

\`docs/\` is gitignored. Wiring this up to GitHub Pages on release is intentionally **out of scope** for this PR — covered separately if we want it.

## What changed

- \`lib/track.ts\` — TSDoc on \`TrackClient\` and all 11 public methods
- \`lib/api.ts\` — TSDoc on \`APIClient\`, all 13 public methods, \`DeliveryExportMetric\`, \`DeliveryExportRequestOptions\`
- \`lib/api/requests.ts\` — TSDoc on \`SendEmailRequest\` (+ \`.attach()\`), \`SendPushRequest\`, \`SendSMSRequest\`, \`SendInboxMessageRequest\`, \`SendInAppRequest\`
- \`lib/regions.ts\` — TSDoc on \`Region\`, \`RegionUS\`, \`RegionEU\`
- \`lib/types.ts\` — TSDoc on \`IdentifierType\`, \`FilterOperator\`, and every filter type
- \`lib/utils.ts\` — TSDoc on \`CustomerIORequestError\`, \`MissingParamError\`, \`isEmpty\`, \`isIdentifierType\`
- \`package.json\` — adds \`typedoc\` devDep + \`docs\` script
- \`typedoc.json\` — config
- \`.gitignore\` — ignores generated \`docs/\`

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — all tests pass, nyc 100% coverage gate holds (no behavior change)
- [x] \`npm run docs\` — generates the reference site to \`docs/\` (0 errors)

## Known follow-ups (not in this PR)

- TypeDoc emits 14 warnings about types that are referenced in method signatures but not directly re-exported from \`index.ts\` (\`EmailMessage\`, \`RequestData\`, \`PushRequestData\`, the \`Send*RequestOptions\` unions). These are de-facto public but not formally exported. Surfacing them is a small API-surface change worth its own ticket.
- GitHub Pages publish on release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly comments and dev tooling; the only runtime change is the `getAttributes` validation error message string, which could affect callers that match on `customerId is required`.
> 
> **Overview**
> Adds **TSDoc** across the public SDK surface (`TrackClient`, `APIClient`, `PipelinesClient`, `Send*Request` builders, regions, filter types, and error helpers) so IDEs get `@param` / `@returns` / `@throws` and examples on hover.
> 
> Introduces a **TypeDoc** workflow: `typedoc` dev dependency, `typedoc.json`, `npm run docs` (output to gitignored `docs/`).
> 
> **Package entrypoint** (`index.ts`) now re-exports more types (`MissingParamError`, `ResponseLike`, `RequestDefaults`, transactional message types/options) instead of only `RetryOptions` from `request`.
> 
> **Behavior change:** `APIClient.getAttributes` throws `MissingParamError('id')` when the identifier is missing (was `'customerId'`); tests updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37ba34bbc1a277dfca1a681dc548c480cad5d203. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->