### PR TITLE
CDP-6026: force transitive uuid to ^11.1.1 to resolve Dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3734,14 +3734,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {
@@ -5333,7 +5336,7 @@
         "istanbul-lib-coverage": "^3.2.0",
         "p-map": "^3.0.0",
         "rimraf": "^6.1.3",
-        "uuid": "^8.3.2"
+        "uuid": "^11.1.1"
       },
       "dependencies": {
         "p-map": {
@@ -6471,9 +6474,9 @@
       }
     },
     "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,9 @@
     "ts-node": "^10.9.1",
     "typescript": "^4.9.4"
   },
+  "overrides": {
+    "uuid": "^11.1.1"
+  },
   "homepage": "https://github.com/customerio/customerio-node",
   "keywords": [
     "customerio",


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #40](https://github.com/customerio/customerio-node/security/dependabot/40) (medium severity: missing buffer bounds check in uuid v3/v5/v6 when `buf` is provided).

`uuid@8.3.2` enters the dependency tree only as a devDep transitive: `nyc -> istanbul-lib-processinfo -> uuid`. Its vulnerable code path (the `buf` parameter to v3/v5/v6) is not reached by nyc's usage, so the real exposure is essentially zero. The shipped SDK has no dependency on uuid at all. Still, an `overrides` entry in `package.json` is the cheapest way to silence the security tab without a wider toolchain bump.

## Test plan

- [x] `npm install` reports `0 vulnerabilities`
- [x] `npm ls uuid` shows the override taking effect (`uuid@11.1.1 overridden`)
- [x] `npm run build` clean
- [x] `npm test` passes, nyc 100% coverage gate holds

The change is two files: `package.json` (new `overrides` block) and `package-lock.json` (regenerated lockfile).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dev dependency bump with no application source changes and no runtime uuid usage in the shipped package.
> 
> **Overview**
> Adds an npm **`overrides`** entry in `package.json` so every resolved **`uuid`** dependency is forced to **`^11.1.1`**, and regenerates **`package-lock.json`** accordingly (8.3.2 → 11.1.1).
> 
> This addresses a Dependabot alert on the transitive **`uuid`** pulled in via **`nyc` → `istanbul-lib-processinfo`**. The published SDK does not depend on **`uuid`**; only the dev/test toolchain is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3805017de271cf2dcdc6446bec6afcb76c7682dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->