### PR TITLE
CDP-5968: fix instanceof checks for cross-realm / duplicate-package safety

### DIFF
--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -1,3 +1,9 @@
+const SEND_EMAIL_BRAND = Symbol.for('customerio-node.SendEmailRequest');
+const SEND_PUSH_BRAND = Symbol.for('customerio-node.SendPushRequest');
+const SEND_SMS_BRAND = Symbol.for('customerio-node.SendSMSRequest');
+const SEND_INBOX_MESSAGE_BRAND = Symbol.for('customerio-node.SendInboxMessageRequest');
+const SEND_IN_APP_BRAND = Symbol.for('customerio-node.SendInAppRequest');
+
 export type Identifiers = { id: string | number } | { email: string };
 
 export type SendEmailRequestRequiredOptions = {
@@ -45,7 +51,12 @@ export type EmailMessage = Partial<SendEmailRequestWithTemplate & SendEmailReque
 export class SendEmailRequest {
   message: EmailMessage;
 
+  static [Symbol.hasInstance](instance: unknown): instance is SendEmailRequest {
+    return typeof instance === 'object' && instance !== null && (instance as any)[SEND_EMAIL_BRAND] === true;
+  }
+
   constructor(opts: SendEmailRequestOptions) {
+    Object.defineProperty(this, SEND_EMAIL_BRAND, { value: true });
     this.message = {
       to: opts.to,
       identifiers: opts.identifiers,
@@ -143,7 +154,12 @@ export type PushMessage = Partial<
 export class SendPushRequest {
   message: PushMessage;
 
+  static [Symbol.hasInstance](instance: unknown): instance is SendPushRequest {
+    return typeof instance === 'object' && instance !== null && (instance as any)[SEND_PUSH_BRAND] === true;
+  }
+
   constructor(opts: SendPushRequestOptions) {
+    Object.defineProperty(this, SEND_PUSH_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
       to: opts.to,
@@ -191,7 +207,12 @@ export type SendSMSRequestOptions = SendSMSRequestRequiredOptions & SendSMSReque
 export class SendSMSRequest {
   message: SMSMessage;
 
+  static [Symbol.hasInstance](instance: unknown): instance is SendSMSRequest {
+    return typeof instance === 'object' && instance !== null && (instance as any)[SEND_SMS_BRAND] === true;
+  }
+
   constructor(opts: SendSMSRequestOptions) {
+    Object.defineProperty(this, SEND_SMS_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
       to: opts.to,
@@ -227,7 +248,12 @@ export type SendInboxMessageRequestOptions = SendInboxMessageRequestRequiredOpti
 export class SendInboxMessageRequest {
   message: InboxMessage;
 
+  static [Symbol.hasInstance](instance: unknown): instance is SendInboxMessageRequest {
+    return typeof instance === 'object' && instance !== null && (instance as any)[SEND_INBOX_MESSAGE_BRAND] === true;
+  }
+
   constructor(opts: SendInboxMessageRequestOptions) {
+    Object.defineProperty(this, SEND_INBOX_MESSAGE_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
       transactional_message_id: opts.transactional_message_id,
@@ -260,7 +286,12 @@ export type SendInAppRequestOptions = SendInAppRequestRequiredOptions & SendInAp
 export class SendInAppRequest {
   message: InAppMessage;
 
+  static [Symbol.hasInstance](instance: unknown): instance is SendInAppRequest {
+    return typeof instance === 'object' && instance !== null && (instance as any)[SEND_IN_APP_BRAND] === true;
+  }
+
   constructor(opts: SendInAppRequestOptions) {
+    Object.defineProperty(this, SEND_IN_APP_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
       transactional_message_id: opts.transactional_message_id,

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -1,9 +1,16 @@
+const REGION_BRAND = Symbol.for('customerio-node.Region');
+
 export class Region {
   readonly trackUrl: string;
   readonly trackV2Url: string;
   readonly apiUrl: string;
 
+  static [Symbol.hasInstance](instance: unknown): instance is Region {
+    return typeof instance === 'object' && instance !== null && (instance as any)[REGION_BRAND] === true;
+  }
+
   constructor(trackUrl: string, apiUrl: string) {
+    Object.defineProperty(this, REGION_BRAND, { value: true });
     this.trackUrl = trackUrl;
     this.trackV2Url = trackUrl.replace('/api/v1', '/api/v2');
     this.apiUrl = apiUrl;

--- a/test/api.ts
+++ b/test/api.ts
@@ -792,3 +792,24 @@ ID_INPUTS.forEach(([input, expected]) => {
     );
   });
 });
+
+test('sendEmail: cross-copy branded object passes instanceof check', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+
+  const brand = Symbol.for('customerio-node.SendEmailRequest');
+  const fakeCrossCopyReq = { message: { to: 'test@example.com', identifiers: { id: '2' }, attachments: {} } };
+  Object.defineProperty(fakeCrossCopyReq, brand, { value: true });
+
+  t.notThrows(() => t.context.client.sendEmail(fakeCrossCopyReq as any));
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/send/email`, fakeCrossCopyReq.message),
+  );
+});
+
+test('constructor: cross-copy branded Region passes instanceof check', (t) => {
+  const brand = Symbol.for('customerio-node.Region');
+  const fakeRegion = { trackUrl: 'https://track.example.com/api/v1', apiUrl: 'https://api.example.com/v1' };
+  Object.defineProperty(fakeRegion, brand, { value: true });
+
+  t.notThrows(() => new APIClient('appKey', { region: fakeRegion as any }));
+});


### PR DESCRIPTION
## Summary
- Add `Symbol.for()` brand markers to all request classes (`SendEmailRequest`, `SendPushRequest`, `SendSMSRequest`, `SendInboxMessageRequest`, `SendInAppRequest`) and `Region`
- Override `Symbol.hasInstance` on each class so `instanceof` uses the brand instead of the prototype chain — this makes `instanceof` work transparently even when the package is duplicated in `node_modules` (common with pnpm/workspaces)
- Brands are non-enumerable (`Object.defineProperty`) to avoid leakage through `Object.assign`/spread
- The `instanceof` call sites in `lib/api.ts` and `lib/track.ts` are unchanged — they now just work correctly across package copies

## Test plan
- [x] All 160 existing tests pass (100% coverage maintained)
- [x] New regression tests verify cross-copy branded objects pass `instanceof`
- [x] Existing "plain object throws an error" tests still pass (plain objects lack the brand)
- [x] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)