### PR TITLE
CDP-6030: live dogfood suite + README/CHANGELOG for v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,38 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.0.0]
+
+The internals of `lib/request.ts` have been rewritten on top of native `fetch` (no more `https.request`). The public method surface is unchanged. Most users will not need to update any code; the one TypeScript-only break is documented below.
+
+#### Breaking (TypeScript only)
+
+- **`CustomerIORequestError.response` type narrowed.** It is now a `ResponseLike` interface (`{ statusCode: number; headers: Record<string, string>; ok: boolean }`) instead of `http.IncomingMessage`. The runtime properties that the SDK has always populated (`statusCode`, response `headers`) are preserved. If your code reads `err.response.rawHeaders` or `err.response.socket`, or uses `instanceof http.IncomingMessage`, update it to read the lowercased `err.response.headers` object instead.
+
+#### Changed
+
+- **Outbound header names are now lowercased on the wire.** This is per the WHATWG fetch spec. The Customer.io API is case-insensitive, so this only matters if you grep your own outbound HTTP logs.
+- **TCP keepalive is enabled by default.** undici's connection pool reuses sockets across calls. Performance improves under sustained load; file-descriptor usage profile shifts slightly.
+- **`User-Agent` bumps from `Customer.io Node Client/4.x` to `Customer.io Node Client/5.0.0`.**
+
+#### Added
+
+- **Bun support.** Bun (latest) is now part of the CI matrix alongside Node 22 / 24 / 26. Runtimes that implement standard `fetch` should work, though only Bun and Node are explicitly tested.
+- **307 and 308 redirects are now explicitly covered** in the test suite (previously only 301/302 had direct test coverage).
+- **Live dogfood suite** (`npm run test:live`). Pre-release smoke test against a real workspace. Not part of `npm test`; gated on `CIO_LIVE=1` plus credentials.
+
+#### Internal
+
+- `lib/request.ts` rewritten on top of native `fetch` with `redirect: 'manual'` and `AbortSignal.timeout`. The Authorization-strip rule on cross-host redirects, the timeout error message string, and `err.code` on network errors (`ECONNREFUSED` / `ENOTFOUND` / `ECONNRESET`) are all preserved. No runtime dependency on the `https` module.
+- `nock` upgraded to `^14` (the only version that intercepts undici's `fetch`).
+
 ## [4.5.1]
 
 #### Fixed
 
 - Fix redirect handler shadowing request body with response body ([#185](https://github.com/customerio/customerio-node/pull/185))
 - Strip Authorization header on non-customer.io redirects ([#186](https://github.com/customerio/customerio-node/pull/186))
-- URL-encode path parameters in APIClient  ([#187](https://github.com/customerio/customerio-node/pull/187))
+- URL-encode path parameters in APIClient ([#187](https://github.com/customerio/customerio-node/pull/187))
 
 ## [4.5.0]
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ The `engines` field in `package.json` reflects the current minimum supported ver
 
 ## Alternative Node runtimes
 
-Many runtimes often have subtle differences to the APIs and standard library offered by Node.js. These differences can cause issues when using this library with those runtimes.
+As of v5.0.0 the SDK is built on top of standard `fetch`, so it runs on any runtime that implements the [WHATWG fetch standard](https://fetch.spec.whatwg.org/).
 
-If you would like to use Customer.io with an alternate runtime, we recommend using either our [Track](https://customer.io/docs/api/#tag/trackOverview) and [App](https://customer.io/docs/api/#tag/appOverview) APIs directly using the built-in HTTP client available in your runtime, or our [React Native SDK](https://customer.io/docs/sdk/react-native/getting-started/) if applicable.
+[Bun](https://bun.sh/) is exercised in CI alongside Node.js, so the supported matrix is:
+
+- Node.js (Current, Active LTS, Maintenance LTS; see [Supported Node.js versions](#supported-nodejs-versions) above)
+- Bun (latest)
+
+Other fetch-compatible runtimes (Deno, Cloudflare Workers, etc.) should work but are not part of our test matrix. If you hit a runtime-specific issue, please open one against the [issue tracker](https://github.com/customerio/customerio-node/issues).
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     ],
     "files": [
       "test/**/*.ts",
-      "!test/fixtures/record.ts"
+      "!test/fixtures/record.ts",
+      "!test/integration/**"
     ]
   },
   "nyc": {
@@ -88,6 +89,7 @@
     "test": "nyc ava",
     "test:record": "CIO_RECORD=1 ts-node test/fixtures/record.ts",
     "test:replay": "ava test/fixtures/replay.ts",
+    "test:live": "CIO_LIVE=1 ava test/integration/live.ts",
     "build": "tsc -p tsconfig.json",
     "prepublishOnly": "npm run build",
     "prepare": "husky install",

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -1,0 +1,242 @@
+/**
+ * Live dogfood suite.
+ *
+ * Runs the SDK against a real Customer.io workspace. NOT gated in CI; this is
+ * the pre-release sanity check, executed locally before cutting a release.
+ *
+ * Required env vars to actually run anything:
+ *   CIO_LIVE=1
+ *   CIO_SITE_ID, CIO_API_KEY    (Track API credentials)
+ *   CIO_APP_KEY                 (App API bearer token)
+ *
+ * Optional env vars, each gates a specific test (absent => skipped):
+ *   CIO_REGION                       "us" | "eu" (default "us")
+ *   CIO_TEST_EMAIL_RECIPIENT         destination address for sendEmail
+ *   CIO_TEST_TRANSACTIONAL_ID        transactional_message_id for sendEmail
+ *   CIO_TEST_BROADCAST_ID            broadcast id for triggerBroadcast
+ *   CIO_TEST_NEWSLETTER_ID           newsletter id for createDeliveriesExport
+ *   CIO_TEST_SMS_TRANSACTIONAL_ID    transactional_message_id for sendSMS
+ *   CIO_TEST_SMS_RECIPIENT           E.164 phone number for sendSMS
+ *   CIO_TEST_PUSH_TRANSACTIONAL_ID   transactional_message_id for sendPush
+ *   CIO_TEST_PUSH_DEVICE_ID          device id for sendPush + addDevice
+ *
+ * Profile lifecycle: one throwaway customer per run, id = `sdk-live-${uuid()}`.
+ * Cleanup is best-effort; the dedicated workspace tolerates orphans.
+ */
+import test from 'ava';
+import { randomUUID } from 'crypto';
+import { TrackClient } from '../../lib/track';
+import { APIClient } from '../../lib/api';
+import {
+  SendEmailRequest,
+  SendSMSRequest,
+  SendPushRequest,
+  SendInAppRequest,
+  SendInboxMessageRequest,
+} from '../../lib/api/requests';
+import { RegionUS, RegionEU } from '../../lib/regions';
+import { IdentifierType } from '../../lib/types';
+
+const isLive = process.env.CIO_LIVE === '1';
+const siteId = process.env.CIO_SITE_ID ?? '';
+const apiKey = process.env.CIO_API_KEY ?? '';
+const appKey = process.env.CIO_APP_KEY ?? '';
+const region = process.env.CIO_REGION === 'eu' ? RegionEU : RegionUS;
+
+const customerId = `sdk-live-${randomUUID()}`;
+const secondaryCustomerId = `sdk-live-${randomUUID()}`;
+const anonymousId = `sdk-live-anon-${randomUUID()}`;
+const deviceId = process.env.CIO_TEST_PUSH_DEVICE_ID ?? `sdk-live-device-${randomUUID()}`;
+const customerEmail = `${customerId}@example.com`;
+
+const track = isLive ? new TrackClient(siteId, apiKey, { region }) : null;
+const api = isLive ? new APIClient(appKey, { region }) : null;
+
+const liveTest = isLive && siteId && apiKey && appKey ? test.serial : test.serial.skip;
+const needs = (envVar: string) => (process.env[envVar] ? liveTest : test.serial.skip);
+
+if (!isLive) {
+  test('live suite skipped (set CIO_LIVE=1 + CIO_SITE_ID/CIO_API_KEY/CIO_APP_KEY to run)', (t) => t.pass());
+}
+
+// 1. Read-only
+
+liveTest('getCustomersByEmail returns the expected shape for an unknown address', async (t) => {
+  const result = (await api!.getCustomersByEmail(`absent-${randomUUID()}@example.com`)) as { results: unknown[] };
+  t.true(Array.isArray(result.results));
+  t.is(result.results.length, 0);
+});
+
+liveTest('listExports resolves', async (t) => {
+  const result = (await api!.listExports()) as { exports: unknown };
+  t.true('exports' in result);
+});
+
+// 2. Idempotent writes. Order matters: later tests assume the profile exists.
+
+liveTest('identify creates the throwaway profile', async (t) => {
+  await track!.identify(customerId, {
+    email: customerEmail,
+    created_at: Math.floor(Date.now() / 1000),
+    first_name: 'SDK',
+    last_name: 'Live',
+    plan: 'sdk-test',
+  });
+  t.pass();
+});
+
+liveTest('getAttributes returns the seeded profile', async (t) => {
+  const result = (await api!.getAttributes(customerId, IdentifierType.Id)) as {
+    customer: { attributes: Record<string, string> };
+  };
+  t.is(result.customer.attributes.first_name, 'SDK');
+});
+
+liveTest('track records an event on the profile', async (t) => {
+  await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
+  t.pass();
+});
+
+liveTest('trackAnonymous records an anonymous event', async (t) => {
+  await track!.trackAnonymous(anonymousId, { name: 'sdk_live_anonymous_event' });
+  t.pass();
+});
+
+liveTest('trackPageView records a page view on the profile', async (t) => {
+  await track!.trackPageView(customerId, '/sdk-live-test');
+  t.pass();
+});
+
+liveTest('addDevice attaches a device to the profile', async (t) => {
+  await track!.addDevice(customerId, deviceId, 'ios', { last_used: Math.floor(Date.now() / 1000) });
+  t.pass();
+});
+
+liveTest('batch sends a mixed batch', async (t) => {
+  await track!.batch([
+    {
+      type: 'person',
+      action: 'identify',
+      identifiers: { id: customerId },
+      attributes: { batched_at: new Date().toISOString() },
+    },
+    {
+      type: 'person',
+      action: 'event',
+      identifiers: { id: customerId },
+      name: 'sdk_live_batch_event',
+    },
+  ]);
+  t.pass();
+});
+
+// 3. Sends. Each is gated on its own env var since they require workspace-specific IDs.
+
+needs('CIO_TEST_TRANSACTIONAL_ID')('sendEmail delivers a transactional message', async (t) => {
+  const recipient = process.env.CIO_TEST_EMAIL_RECIPIENT;
+  if (!recipient) {
+    t.pass('CIO_TEST_EMAIL_RECIPIENT not set; skipping send');
+    return;
+  }
+  const req = new SendEmailRequest({
+    to: recipient,
+    identifiers: { id: customerId },
+    transactional_message_id: process.env.CIO_TEST_TRANSACTIONAL_ID!,
+    message_data: { run: customerId },
+  });
+  const result = (await api!.sendEmail(req)) as { delivery_id?: string };
+  t.truthy(result.delivery_id);
+});
+
+needs('CIO_TEST_SMS_TRANSACTIONAL_ID')('sendSMS delivers a transactional SMS', async (t) => {
+  const recipient = process.env.CIO_TEST_SMS_RECIPIENT;
+  if (!recipient) {
+    t.pass('CIO_TEST_SMS_RECIPIENT not set; skipping send');
+    return;
+  }
+  const req = new SendSMSRequest({
+    to: recipient,
+    identifiers: { id: customerId },
+    transactional_message_id: process.env.CIO_TEST_SMS_TRANSACTIONAL_ID!,
+  });
+  const result = (await api!.sendSMS(req)) as { delivery_id?: string };
+  t.truthy(result.delivery_id);
+});
+
+needs('CIO_TEST_PUSH_TRANSACTIONAL_ID')('sendPush delivers a transactional push', async (t) => {
+  const req = new SendPushRequest({
+    identifiers: { id: customerId },
+    transactional_message_id: process.env.CIO_TEST_PUSH_TRANSACTIONAL_ID!,
+  });
+  const result = (await api!.sendPush(req)) as { delivery_id?: string };
+  t.truthy(result.delivery_id);
+});
+
+needs('CIO_TEST_INAPP_TRANSACTIONAL_ID')('sendInApp delivers an in-app message', async (t) => {
+  const req = new SendInAppRequest({
+    identifiers: { id: customerId },
+    transactional_message_id: process.env.CIO_TEST_INAPP_TRANSACTIONAL_ID!,
+  });
+  const result = (await api!.sendInApp(req)) as { delivery_id?: string };
+  t.truthy(result.delivery_id);
+});
+
+needs('CIO_TEST_INBOX_TRANSACTIONAL_ID')('sendInboxMessage delivers an inbox message', async (t) => {
+  const req = new SendInboxMessageRequest({
+    identifiers: { id: customerId },
+    transactional_message_id: process.env.CIO_TEST_INBOX_TRANSACTIONAL_ID!,
+  });
+  const result = (await api!.sendInboxMessage(req)) as { delivery_id?: string };
+  t.truthy(result.delivery_id);
+});
+
+// 4. Broadcasts / exports
+
+needs('CIO_TEST_BROADCAST_ID')('triggerBroadcast resolves against a test broadcast', async (t) => {
+  const result = (await api!.triggerBroadcast(
+    process.env.CIO_TEST_BROADCAST_ID!,
+    { run: customerId },
+    { ids: [customerId] },
+  )) as { id?: number };
+  t.truthy(result.id);
+});
+
+liveTest('createCustomersExport queues an export', async (t) => {
+  const filters = { or: [{ segment: { id: 0 } }] } as unknown as Parameters<APIClient['createCustomersExport']>[0];
+  const result = (await api!.createCustomersExport(filters)) as { export?: { id: number } };
+  t.truthy(result.export);
+});
+
+needs('CIO_TEST_NEWSLETTER_ID')('createDeliveriesExport queues an export', async (t) => {
+  const result = (await api!.createDeliveriesExport(Number(process.env.CIO_TEST_NEWSLETTER_ID!))) as {
+    export?: { id: number };
+  };
+  t.truthy(result.export);
+});
+
+// 5. Destructive cleanup. Runs last; failures here are warnings on a dedicated
+// test workspace.
+
+liveTest('deleteDevice removes the device from the profile', async (t) => {
+  await track!.deleteDevice(customerId, deviceId).catch(() => undefined);
+  t.pass();
+});
+
+liveTest('suppress + unsuppress round-trip', async (t) => {
+  await track!.suppress(customerId).catch(() => undefined);
+  await track!.unsuppress(customerId).catch(() => undefined);
+  t.pass();
+});
+
+liveTest('mergeCustomers merges a secondary profile into the primary', async (t) => {
+  await track!.identify(secondaryCustomerId, { email: `${secondaryCustomerId}@example.com` }).catch(() => undefined);
+  await track!
+    .mergeCustomers(IdentifierType.Id, customerId, IdentifierType.Id, secondaryCustomerId)
+    .catch(() => undefined);
+  t.pass();
+});
+
+liveTest('destroy deletes the throwaway profile', async (t) => {
+  await track!.destroy(customerId).catch(() => undefined);
+  t.pass();
+});


### PR DESCRIPTION
PR 3 of the v5.0 fetch swap. After this lands, the SDK is ready for the release PR.

Linear: [CDP-6030](https://linear.app/customerio/issue/CDP-6030)

## `test/integration/live.ts` (new)

- AVA suite, **NOT run by default**. Gated on `CIO_LIVE=1` plus `CIO_SITE_ID` / `CIO_API_KEY` / `CIO_APP_KEY`.
- Test order: read-only -> idempotent writes -> sends -> broadcasts / exports -> destructive cleanup. One throwaway profile per run (`sdk-live-<uuid>`).
- Send / broadcast / export tests are each gated on their own workspace-specific env var (`CIO_TEST_TRANSACTIONAL_ID`, `CIO_TEST_BROADCAST_ID`, `CIO_TEST_NEWSLETTER_ID`, etc.) so the suite is usable with only Track + App credentials and degrades to skips for anything you don't have wired up.
- Cleanup is best-effort; the dedicated SDK-testing workspace tolerates orphans by design.

## `package.json`

- New `test:live` script that sets `CIO_LIVE=1` and runs ava on the file.
- AVA `files` config excludes `test/integration/**` so the live suite never runs as part of `npm test`.

## `README.md`

Alternative Node runtimes section rewritten. v5 retires the 'we recommend hitting the API directly' warning. Bun is in the supported matrix; any runtime with standard `fetch` should work but only Node and Bun are explicitly tested.

## `CHANGELOG.md`

New `[5.0.0]` entry. Calls out:
- The one TypeScript-only breaking change (`CustomerIORequestError.response` is now `ResponseLike`, not `http.IncomingMessage`) plus a migration note.
- Header casing now lowercased on the wire (WHATWG fetch).
- TCP keepalive default flip (undici pool).
- `User-Agent` bumps to `5.0.0`.
- New Bun support and 307/308 coverage gap fill.
- `lib/request.ts` is now fetch-based; no runtime dep on `https`.
- `nock` upgraded to `^14`.

## Verification

- `npm test` -> 186 pass, 100% coverage. Live suite excluded from the default run.
- `npm run build` -> clean.
- `npx ava test/integration/live.ts` with no env -> 1 placeholder passes, 21 live tests skip.

## Pre-release manual checklist (deferred to release PR)

- `CIO_LIVE=1 CIO_SITE_ID=... CIO_API_KEY=... CIO_APP_KEY=... npm run test:live` against the dedicated workspace, with the optional send / broadcast / newsletter env vars populated.
- Smoke-test each of the 10 files in `examples/` against the dedicated workspace.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime library changes in this diff; only docs, package scripts, and opt-in tests against a real workspace when env vars are set.
> 
> **Overview**
> Adds **v5.0.0 release notes** and **README** updates for the fetch-based SDK: documents the TypeScript-only `CustomerIORequestError.response` shape change, wire-level header casing, keepalive/User-Agent, Bun in CI, and related test/internal notes.
> 
> Introduces an **optional live dogfood suite** (`test/integration/live.ts`) run via `npm run test:live` when `CIO_LIVE=1` and credentials are set. Serial tests hit real Track/App APIs (read-only → writes → optional sends/exports → cleanup) with per-feature env var skips. **Default `npm test` excludes** `test/integration/**` so CI and local unit runs stay unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3153738192895e15d642180759ebd221f215b2d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->