### PR TITLE
CDP-5974: refactor SendXRequest classes to reduce boilerplate

### DIFF
--- a/lib/api/requests.ts
+++ b/lib/api/requests.ts
@@ -1,3 +1,5 @@
+import { pickDefined } from '../utils';
+
 const SEND_EMAIL_BRAND = Symbol.for('customerio-node.SendEmailRequest');
 const SEND_PUSH_BRAND = Symbol.for('customerio-node.SendPushRequest');
 const SEND_SMS_BRAND = Symbol.for('customerio-node.SendSMSRequest');
@@ -45,8 +47,25 @@ export type SendEmailRequestWithoutTemplate = SendEmailRequestRequiredOptions &
 export type SendEmailRequestOptions = SendEmailRequestWithTemplate | SendEmailRequestWithoutTemplate;
 
 export type EmailMessage = Partial<SendEmailRequestWithTemplate & SendEmailRequestWithoutTemplate> & {
-  attachments: Record<string, string>;
+  attachments?: Record<string, string>;
 };
+
+const EMAIL_OPTIONAL_KEYS = [
+  'message_data',
+  'preheader',
+  'reply_to',
+  'bcc',
+  'body_plain',
+  'body_amp',
+  'fake_bcc',
+  'disable_message_retention',
+  'send_to_unsubscribed',
+  'tracked',
+  'queue_draft',
+  'send_at',
+  'disable_css_preprocessing',
+  'language',
+] as const satisfies ReadonlyArray<keyof SendEmailRequestOptionalOptions>;
 
 export class SendEmailRequest {
   message: EmailMessage;
@@ -60,22 +79,8 @@ export class SendEmailRequest {
     this.message = {
       to: opts.to,
       identifiers: opts.identifiers,
-      attachments: {},
-      message_data: opts.message_data,
       headers: opts.headers || {},
-      preheader: opts.preheader,
-      reply_to: opts.reply_to,
-      bcc: opts.bcc,
-      body_plain: opts.body_plain,
-      body_amp: opts.body_amp,
-      fake_bcc: opts.fake_bcc,
-      disable_message_retention: opts.disable_message_retention,
-      send_to_unsubscribed: opts.send_to_unsubscribed,
-      tracked: opts.tracked,
-      queue_draft: opts.queue_draft,
-      send_at: opts.send_at,
-      disable_css_preprocessing: opts.disable_css_preprocessing,
-      language: opts.language,
+      ...pickDefined(opts, EMAIL_OPTIONAL_KEYS),
     };
 
     if ('transactional_message_id' in opts) {
@@ -98,6 +103,8 @@ export class SendEmailRequest {
   // Use `any` for data here, because union types and overloads in Typescript
   // don't work well together for `Buffer.from`.
   attach(name: string, data: any, { encode = true } = {}) {
+    this.message.attachments ??= {};
+
     if (this.message.attachments[name]) {
       throw new Error(`attachment ${name} already exists`);
     }
@@ -151,6 +158,22 @@ export type PushMessage = Partial<
   Omit<SendPushRequestWithoutCustomPayload, 'device'> & Omit<SendPushRequestWithCustomPayload, 'device'>
 >;
 
+const PUSH_OPTIONAL_KEYS = [
+  'to',
+  'title',
+  'message',
+  'disable_message_retention',
+  'send_to_unsubscribed',
+  'queue_draft',
+  'message_data',
+  'send_at',
+  'language',
+  'image_url',
+  'link',
+  'sound',
+  'custom_data',
+] as const satisfies ReadonlyArray<keyof SendPushRequestOptionalOptions>;
+
 export class SendPushRequest {
   message: PushMessage;
 
@@ -162,21 +185,10 @@ export class SendPushRequest {
     Object.defineProperty(this, SEND_PUSH_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
-      to: opts.to,
       transactional_message_id: opts.transactional_message_id,
-      title: opts.title,
-      message: opts.message,
-      disable_message_retention: opts.disable_message_retention,
-      send_to_unsubscribed: opts.send_to_unsubscribed,
-      queue_draft: opts.queue_draft,
-      message_data: opts.message_data,
-      send_at: opts.send_at,
-      language: opts.language,
-      image_url: opts.image_url,
-      link: opts.link,
-      sound: opts.sound,
-      custom_data: opts.custom_data,
-      custom_device: opts.device,
+      ...pickDefined(opts, PUSH_OPTIONAL_KEYS),
+      // opts.device maps to custom_device on the wire
+      ...(opts.device !== undefined && { custom_device: opts.device }),
     };
 
     if ('custom_payload' in opts) {
@@ -204,6 +216,16 @@ export type SendSMSRequestOptionalOptions = Partial<{
 
 export type SendSMSRequestOptions = SendSMSRequestRequiredOptions & SendSMSRequestOptionalOptions & {};
 
+const SMS_OPTIONAL_KEYS = [
+  'to',
+  'disable_message_retention',
+  'send_to_unsubscribed',
+  'queue_draft',
+  'message_data',
+  'send_at',
+  'language',
+] as const satisfies ReadonlyArray<keyof SendSMSRequestOptionalOptions>;
+
 export class SendSMSRequest {
   message: SMSMessage;
 
@@ -215,14 +237,8 @@ export class SendSMSRequest {
     Object.defineProperty(this, SEND_SMS_BRAND, { value: true });
     this.message = {
       identifiers: opts.identifiers,
-      to: opts.to,
       transactional_message_id: opts.transactional_message_id,
-      disable_message_retention: opts.disable_message_retention,
-      send_to_unsubscribed: opts.send_to_unsubscribed,
-      queue_draft: opts.queue_draft,
-      message_data: opts.message_data,
-      send_at: opts.send_at,
-      language: opts.language,
+      ...pickDefined(opts, SMS_OPTIONAL_KEYS),
     };
   }
 }
@@ -245,6 +261,14 @@ export type SendInboxMessageRequestOptionalOptions = Partial<{
 export type SendInboxMessageRequestOptions = SendInboxMessageRequestRequiredOptions &
   SendInboxMessageRequestOptionalOptions & {};
 
+const INBOX_OPTIONAL_KEYS = [
+  'disable_message_retention',
+  'queue_draft',
+  'message_data',
+  'send_at',
+  'language',
+] as const satisfies ReadonlyArray<keyof SendInboxMessageRequestOptionalOptions>;
+
 export class SendInboxMessageRequest {
   message: InboxMessage;
 
@@ -257,11 +281,7 @@ export class SendInboxMessageRequest {
     this.message = {
       identifiers: opts.identifiers,
       transactional_message_id: opts.transactional_message_id,
-      disable_message_retention: opts.disable_message_retention,
-      queue_draft: opts.queue_draft,
-      message_data: opts.message_data,
-      send_at: opts.send_at,
-      language: opts.language,
+      ...pickDefined(opts, INBOX_OPTIONAL_KEYS),
     };
   }
 }
@@ -283,6 +303,14 @@ export type SendInAppRequestOptionalOptions = Partial<{
 
 export type SendInAppRequestOptions = SendInAppRequestRequiredOptions & SendInAppRequestOptionalOptions & {};
 
+const IN_APP_OPTIONAL_KEYS = [
+  'disable_message_retention',
+  'queue_draft',
+  'message_data',
+  'send_at',
+  'language',
+] as const satisfies ReadonlyArray<keyof SendInAppRequestOptionalOptions>;
+
 export class SendInAppRequest {
   message: InAppMessage;
 
@@ -295,11 +323,7 @@ export class SendInAppRequest {
     this.message = {
       identifiers: opts.identifiers,
       transactional_message_id: opts.transactional_message_id,
-      disable_message_retention: opts.disable_message_retention,
-      queue_draft: opts.queue_draft,
-      message_data: opts.message_data,
-      send_at: opts.send_at,
-      language: opts.language,
+      ...pickDefined(opts, IN_APP_OPTIONAL_KEYS),
     };
   }
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -41,6 +41,16 @@ ${json.meta.errors.map((error: string) => `  - ${error}`).join('\n')}`;
   }
 }
 
+export function pickDefined<T extends Record<string, unknown>>(source: T, keys: ReadonlyArray<keyof T>): Partial<T> {
+  const result: Partial<T> = {};
+  for (const key of keys) {
+    if (source[key] !== undefined) {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
 export class MissingParamError extends Error {
   constructor(param: string) {
     super(param);

--- a/test/api.ts
+++ b/test/api.ts
@@ -189,6 +189,18 @@ test('#sendPush: without custom payload: success', (t) => {
   t.falsy(req.message.custom_payload);
 });
 
+test('#sendPush: maps device to custom_device', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  let req = new SendPushRequest({
+    identifiers: { id: '2' },
+    transactional_message_id: 1,
+    device: { token: 'abc123' },
+  });
+
+  t.context.client.sendPush(req);
+  t.deepEqual(req.message.custom_device, { token: 'abc123' });
+});
+
 test('#getCustomersByEmail: searching for a customer email (default)', (t) => {
   sinon.stub(t.context.client.request, 'get');
 
@@ -245,12 +257,17 @@ test('#getCustomersByEmail: should throw error when email is not a string object
   t.throws(() => t.context.client.getCustomersByEmail(email as string));
 });
 
+test('#sendEmail: message does not include attachments key when none are added', (t) => {
+  let req = new SendEmailRequest({ to: 'test@example.com', identifiers: { id: '2' }, transactional_message_id: 1 });
+  t.false('attachments' in req.message);
+});
+
 test('#sendEmail: adding attachments with encoding (default)', (t) => {
   sinon.stub(t.context.client.request, 'post');
   let req = new SendEmailRequest({ to: 'test@example.com', identifiers: { id: '2' }, transactional_message_id: 1 });
 
   req.attach('test', 'hello world');
-  t.is(req.message.attachments.test, Buffer.from('hello world').toString('base64'));
+  t.is(req.message.attachments!.test, Buffer.from('hello world').toString('base64'));
 });
 
 test('#sendEmail: adding attachments without encoding', (t) => {
@@ -258,7 +275,7 @@ test('#sendEmail: adding attachments without encoding', (t) => {
   let req = new SendEmailRequest({ to: 'test@example.com', identifiers: { id: '2' }, transactional_message_id: 1 });
 
   req.attach('file', 'test content', { encode: false });
-  t.truthy(req.message.attachments.file, 'test content');
+  t.truthy(req.message.attachments!.file, 'test content');
 });
 
 test('#sendEmail: adding attachments twice throws an error', (t) => {
@@ -267,7 +284,7 @@ test('#sendEmail: adding attachments twice throws an error', (t) => {
 
   req.attach('test', 'test content');
   t.throws(() => req.attach('test', 'test content 2'), { message: /attachment test already exists/ });
-  t.is(req.message.attachments.test, Buffer.from('test content').toString('base64'));
+  t.is(req.message.attachments!.test, Buffer.from('test content').toString('base64'));
 });
 
 test('#sendEmail: error', async (t) => {


### PR DESCRIPTION
## Summary

- Introduce a `pickDefined` helper in `lib/utils.ts` that filters an object to only include keys with defined values, replacing manual field-by-field constructor mapping in all 5 `Send*Request` classes
- Make `EmailMessage.attachments` optional with lazy initialization in `attach()`, so the SDK no longer serializes empty `attachments: {}` when no attachments are added
- Add test coverage for the `device` → `custom_device` mapping in `SendPushRequest` (previously untested)

## Test plan

- [x] All 160 tests pass (including 2 new tests)
- [x] 100% code coverage maintained across statements, branches, functions, and lines
- [x] `npx tsc --noEmit` passes cleanly
- [x] ESLint + Prettier pass via pre-commit hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal SDK request shaping with behavior-focused tests; main wire change is omitting undefined optionals and empty attachments, which is usually API-friendly.
> 
> **Overview**
> Refactors all five `Send*Request` builders in `lib/api/requests.ts` to use a shared **`pickDefined`** helper so optional fields are copied onto `message` only when they are not `undefined`, replacing long hand-assigned constructor blocks.
> 
> **Email payloads** no longer always include an empty `attachments` object: `attachments` is optional on `EmailMessage`, and `attach()` lazily creates the map. **Push** still maps constructor `device` to wire field `custom_device` via an explicit spread (not in the optional-key list).
> 
> Tests add coverage that email messages omit `attachments` when unused, that push `device` → `custom_device`, and use non-null assertions where `attachments` is created in `attach()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55ec594b4c7545d90e96dce89e32c026363899c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->