### PR TITLE
Add `PipelinesClient` for the Pipelines API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+#### Changed
+
+- **BREAKING:** The `Region` constructor now requires a third `pipelinesUrl` argument. Code that constructs `Region` directly with the two-argument signature (`new Region(trackUrl, apiUrl)`) will fail to type-check and must be updated to pass an explicit Pipelines host. Code that only consumes the exported `RegionUS` and `RegionEU` constants is unaffected.
+
+#### Added
+
+- New `PipelinesClient` for the [Pipelines API](https://docs.customer.io/files/pipelines.json). Provides `identify`, `track`, `page`, `screen`, `group`, `alias`, and `batch` methods. Auto-fills `messageId`, `timestamp`, and `context.library` on every payload, and supports an optional `defaultContext` and `strictMode` on the client. See the new Pipelines section in the README.
+- `Region` now exposes a `pipelinesUrl` field, and `RegionUS` / `RegionEU` point at `cdp.customer.io` and `cdp-eu.customer.io` respectively.
+- `CIORequest.options()` now merges custom headers supplied via `defaults.headers`. Standard headers (`Authorization`, `Content-Type`, `Content-Length`, `User-Agent`) always win and cannot be clobbered.
+
 ## [4.5.1]
 
 #### Fixed

--- a/README.md
+++ b/README.md
@@ -541,6 +541,134 @@ api.createDeliveriesExport(1, {
 
 You can read more about the available options on the [export deliveries data](https://customer.io/docs/api/#operation/exportDeliveriesData) docs.
 
+## Pipelines API
+
+The Pipelines API is Customer.io's ingestion endpoint for the Segment-compatible identify/track/page/screen/group/alias event model. It runs at a different host (`cdp.customer.io`) from the Track and App APIs and authenticates with a **Pipelines write key** (set up under *Data Pipelines → Sources* in the dashboard).
+
+> **Need client-side batching, buffered flushes, or retries?** Use [`@customerio/cdp-analytics-node`](https://www.npmjs.com/package/@customerio/cdp-analytics-node) instead. `PipelinesClient` in this package is a thin, stateless client that issues one HTTP request per call — same as `TrackClient` and `APIClient`.
+
+### Creating a Pipelines client
+
+```js
+const { PipelinesClient, RegionUS, RegionEU } = require('customerio-node');
+
+const pipelines = new PipelinesClient('YOUR_PIPELINES_WRITE_KEY', {
+  region: RegionUS, // or RegionEU; defaults to RegionUS
+});
+```
+
+**Constructor options** (second argument):
+
+- `region`: `RegionUS` or `RegionEU`. Defaults to `RegionUS`.
+- `url`: Override the region-derived host. Useful for testing against a proxy.
+- `strictMode`: When `true`, sends `X-Strict-Mode: 1` on every request so the Pipelines API validates payloads and returns proper HTTP error codes instead of accepting malformed events silently.
+- `defaultContext`: Default `context` values merged under every outgoing payload (per-call `context` always wins on key conflicts). Useful for setting things like `ip` or `locale` once per client instance.
+- `timeout`: HTTP timeout in ms. Defaults to `10_000`.
+
+### Field naming
+
+Pipelines payloads use **camelCase** (`userId`, `anonymousId`, `groupId`, `previousId`, `messageId`) because that's what the API accepts on the wire. This differs from the rest of this SDK, which is snake_case to match the Track and App APIs.
+
+### Auto-filled fields
+
+Every payload is augmented before sending:
+
+- `messageId`: A UUID v4, when not supplied.
+- `timestamp`: The current time as an ISO-8601 string, when not supplied.
+- `context.library`: `{ name: 'customerio-node', version }`, when not supplied.
+
+Per-call values always win, so passing your own `messageId` (e.g. for idempotency) or `timestamp` (e.g. for backfilling) is supported.
+
+### pipelines.identify(payload)
+
+Add or update a person and their traits.
+
+```js
+pipelines.identify({
+  userId: '1',
+  traits: { email: 'customer@example.com', plan: 'pro' },
+});
+```
+
+At least one of `userId` or `anonymousId` is required.
+
+### pipelines.track(payload)
+
+Record an event.
+
+```js
+pipelines.track({
+  userId: '1',
+  event: 'Order Completed',
+  properties: { price: 23.45, product: 'socks' },
+});
+```
+
+At least one of `userId` or `anonymousId` is required. `event` is required.
+
+### pipelines.page(payload)
+
+Log a page view.
+
+```js
+pipelines.page({
+  userId: '1',
+  name: 'Pricing',
+  properties: { path: '/pricing', referrer: 'https://example.com' },
+});
+```
+
+### pipelines.screen(payload)
+
+Capture a mobile screen view from a server-side handler.
+
+```js
+pipelines.screen({
+  userId: '1',
+  name: 'Settings',
+});
+```
+
+### pipelines.group(payload)
+
+Create an object/group and associate a person with it.
+
+```js
+pipelines.group({
+  userId: '1',
+  groupId: 'acme-co',
+  traits: { plan: 'enterprise' },
+});
+```
+
+`groupId` is required, along with at least one of `userId` or `anonymousId`.
+
+### pipelines.alias(payload)
+
+Merge profiles by reconciling identifiers.
+
+```js
+pipelines.alias({
+  userId: '1',
+  previousId: 'anon-abc-123',
+});
+```
+
+Both `userId` and `previousId` are required.
+
+### pipelines.batch(items)
+
+Submit up to 500 KB worth of identify/track/page/screen/group/alias events in a single request. Each item must include a `type` discriminator naming the endpoint it would otherwise have been sent to.
+
+```js
+pipelines.batch([
+  { type: 'identify', userId: '1', traits: { plan: 'pro' } },
+  { type: 'track', userId: '1', event: 'Subscribed', properties: { plan: 'pro' } },
+]);
+```
+
+Each item is enveloped (auto-filled `messageId`, `timestamp`, `context.library`) before sending.
+
 ## Further examples
 
 We've included functional examples in the [examples/ directory](https://github.com/customerio/customerio-node/tree/main/examples) of the repo to further assist in demonstrating how to use this library to integrate with Customer.io

--- a/examples/config.example.js
+++ b/examples/config.example.js
@@ -2,6 +2,7 @@ const config = {
   siteId: 'changeme',
   apiKey: 'changeme',
   appKey: 'changeme',
+  pipelinesWriteKey: 'changeme',
   customerId: '1',
   customerEmail: 'ami@customer.io',
   transactionalMessageId: '1',

--- a/examples/pipelines.js
+++ b/examples/pipelines.js
@@ -1,0 +1,52 @@
+const { PipelinesClient, RegionUS } = require('../dist/index');
+// In actual use require the node module:
+// const { PipelinesClient, RegionUS } = require('customerio-node');
+const writeKey = require('./config').pipelinesWriteKey;
+const customerId = require('./config').customerId;
+
+const cio = new PipelinesClient(writeKey, { region: RegionUS });
+
+// identify a person
+cio.identify({
+  userId: customerId,
+  traits: {
+    email: 'customer@example.com',
+    plan: 'pro',
+  },
+});
+
+// record an event
+cio.track({
+  userId: customerId,
+  event: 'Order Completed',
+  properties: {
+    price: 23.45,
+    product: 'socks',
+  },
+});
+
+// page view from a server-rendered request
+cio.page({
+  userId: customerId,
+  name: 'Pricing',
+  properties: { path: '/pricing' },
+});
+
+// associate the person with an object/group
+cio.group({
+  userId: customerId,
+  groupId: 'acme-co',
+  traits: { plan: 'enterprise' },
+});
+
+// merge an anonymous identity into a known person
+cio.alias({
+  userId: customerId,
+  previousId: 'anon-abc-123',
+});
+
+// batch multiple events in one HTTP request
+cio.batch([
+  { type: 'identify', userId: customerId, traits: { plan: 'pro' } },
+  { type: 'track', userId: customerId, event: 'Subscribed', properties: { plan: 'pro' } },
+]);

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/track';
 export * from './lib/api';
+export * from './lib/pipelines';
 export * from './lib/regions';
 export * from './lib/types';
 export { CustomerIORequestError } from './lib/utils';

--- a/lib/pipelines.ts
+++ b/lib/pipelines.ts
@@ -1,0 +1,166 @@
+import { randomUUID } from 'crypto';
+import type { RequestOptions } from 'https';
+import Request from './request';
+import { Region, RegionUS } from './regions';
+import { isEmpty, MissingParamError } from './utils';
+import { version } from './version';
+import type {
+  AliasPayload,
+  BatchItem,
+  GroupPayload,
+  IdentifyPayload,
+  PagePayload,
+  PipelinesCommon,
+  PipelinesContext,
+  ScreenPayload,
+  TrackPayload,
+} from './pipelines/payloads';
+
+export type PipelinesDefaults = RequestOptions & {
+  region: Region;
+  /** Overrides the region-derived host. Useful for testing against a proxy. */
+  url?: string;
+  /**
+   * When `true`, sends `X-Strict-Mode: 1` on every request. Strict mode asks
+   * the Pipelines API to validate payloads and return proper HTTP error codes
+   * instead of accepting and silently dropping malformed events.
+   */
+  strictMode?: boolean;
+  /**
+   * Default `context` values merged under every outgoing payload. Per-call
+   * `context` always wins on key conflicts. Useful for setting things like
+   * `ip` or `locale` once per client instance.
+   */
+  defaultContext?: PipelinesContext;
+};
+
+export class PipelinesClient {
+  writeKey: string;
+  defaults: PipelinesDefaults;
+  request: Request;
+  pipelinesRoot: string;
+  private readonly autoContext: PipelinesContext;
+
+  constructor(writeKey: string, defaults: Partial<PipelinesDefaults> = {}) {
+    if (isEmpty(writeKey)) {
+      throw new MissingParamError('writeKey');
+    }
+    if (defaults.region && !(defaults.region instanceof Region)) {
+      throw new Error('region must be one of Regions.US or Regions.EU');
+    }
+
+    this.writeKey = writeKey;
+    // Strict mode rides into `defaults.headers` so the `CIORequest.options()`
+    // passthrough delivers it on every request. Existing headers on the
+    // incoming defaults are preserved.
+    const headers = defaults.strictMode ? { ...(defaults.headers ?? {}), 'X-Strict-Mode': '1' } : defaults.headers;
+    this.defaults = { ...defaults, headers, region: defaults.region || RegionUS };
+
+    // The Pipelines API authenticates with HTTP Basic where the write key is
+    // the username and the password is blank. The existing `CIORequest`
+    // BasicAuth helper builds `${siteid}:${apikey}` — we map the write key
+    // into `siteid` and leave `apikey` empty so the encoded credential is
+    // exactly `base64(writeKey:)`. The field names are an internal artifact
+    // and never leak through to the public API.
+    this.request = new Request({ siteid: writeKey, apikey: '' }, this.defaults);
+
+    this.pipelinesRoot = this.defaults.url ? this.defaults.url : this.defaults.region.pipelinesUrl;
+
+    this.autoContext = {
+      ...(this.defaults.defaultContext ?? {}),
+      library: { name: 'customerio-node', version },
+    };
+  }
+
+  identify(payload: IdentifyPayload) {
+    if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
+      throw new MissingParamError('userId or anonymousId');
+    }
+    return this.request.post(`${this.pipelinesRoot}/identify`, this.envelope(payload));
+  }
+
+  track(payload: TrackPayload) {
+    if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
+      throw new MissingParamError('userId or anonymousId');
+    }
+    if (isEmpty(payload?.event)) {
+      throw new MissingParamError('event');
+    }
+    return this.request.post(`${this.pipelinesRoot}/track`, this.envelope(payload));
+  }
+
+  page(payload: PagePayload) {
+    if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
+      throw new MissingParamError('userId or anonymousId');
+    }
+    return this.request.post(`${this.pipelinesRoot}/page`, this.envelope(payload));
+  }
+
+  screen(payload: ScreenPayload) {
+    if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
+      throw new MissingParamError('userId or anonymousId');
+    }
+    return this.request.post(`${this.pipelinesRoot}/screen`, this.envelope(payload));
+  }
+
+  group(payload: GroupPayload) {
+    if (isEmpty(payload?.userId) && isEmpty(payload?.anonymousId)) {
+      throw new MissingParamError('userId or anonymousId');
+    }
+    if (isEmpty(payload?.groupId)) {
+      throw new MissingParamError('groupId');
+    }
+    return this.request.post(`${this.pipelinesRoot}/group`, this.envelope(payload));
+  }
+
+  alias(payload: AliasPayload) {
+    if (isEmpty(payload?.userId)) {
+      throw new MissingParamError('userId');
+    }
+    if (isEmpty(payload?.previousId)) {
+      throw new MissingParamError('previousId');
+    }
+    return this.request.post(`${this.pipelinesRoot}/alias`, this.envelope(payload));
+  }
+
+  batch(items: BatchItem[]) {
+    if (!Array.isArray(items) || items.length === 0) {
+      throw new MissingParamError('items');
+    }
+    const batch = items.map((item) => ({ ...this.envelope(item), type: item.type }));
+    return this.request.post(`${this.pipelinesRoot}/batch`, { batch });
+  }
+
+  // Auto-fills `messageId`, `timestamp`, and `context.library` when the caller
+  // hasn't supplied them. Per-call values always win over the auto-fill and
+  // over `defaultContext`.
+  private envelope<T extends PipelinesCommon>(payload: T): T {
+    const merged: PipelinesContext = {
+      ...this.autoContext,
+      ...(payload.context ?? {}),
+    };
+    // `context.library` is a sub-object — preserve per-call override
+    // explicitly so a partial `context: { ip: '...' }` doesn't drop the
+    // auto-filled library identifier.
+    merged.library = payload.context?.library ?? this.autoContext.library;
+
+    return {
+      ...payload,
+      messageId: payload.messageId ?? randomUUID(),
+      timestamp: payload.timestamp ?? new Date().toISOString(),
+      context: merged,
+    };
+  }
+}
+
+export type {
+  AliasPayload,
+  BatchItem,
+  GroupPayload,
+  IdentifyPayload,
+  PagePayload,
+  PipelinesCommon,
+  PipelinesContext,
+  ScreenPayload,
+  TrackPayload,
+} from './pipelines/payloads';

--- a/lib/pipelines/payloads.ts
+++ b/lib/pipelines/payloads.ts
@@ -1,0 +1,132 @@
+/**
+ * Type definitions for the Customer.io Pipelines API.
+ *
+ * Field names are camelCase end-to-end because that's what the Pipelines API
+ * accepts on the wire (unlike the rest of this SDK, which is snake_case to
+ * match the Track and App APIs). The shape mirrors the message envelope used
+ * by `@customerio/cdp-analytics-node` so users moving between the two
+ * libraries don't need to relearn the payload format.
+ */
+
+/**
+ * Every Pipelines call must identify the person via at least one of `userId`
+ * or `anonymousId`. Both may be present.
+ */
+export type PipelinesIdentifier =
+  | { userId: string | number; anonymousId?: string }
+  | { anonymousId: string; userId?: string | number };
+
+/**
+ * Server-side subset of the Segment/Pipelines `context` object.
+ *
+ * `app`, `device`, `network`, and `os` are intentionally omitted — those
+ * fields are populated automatically by the Customer.io mobile SDKs and have
+ * no meaningful value on a server-side call.
+ */
+export type PipelinesContext = Partial<{
+  active: boolean;
+  campaign: Partial<{
+    name: string;
+    source: string;
+    medium: string;
+    term: string;
+    content: string;
+  }>;
+  ip: string;
+  /**
+   * Identifies the library producing the call. Auto-filled by `PipelinesClient`
+   * with this package's name and version; per-call overrides win.
+   */
+  library: { name: string; version: string };
+  locale: string;
+  location: Partial<{
+    city: string;
+    country: string;
+    latitude: number;
+    longitude: number;
+    region: string;
+    speed: number;
+  }>;
+  page: Partial<{
+    hash: string;
+    path: string;
+    referrer: string;
+    search: string;
+    title: string;
+    url: string;
+  }>;
+  referrer: Partial<{
+    type: string;
+    name: string;
+    url: string;
+    link: string;
+  }>;
+  timezone: string;
+  groupId: string;
+  traits: Record<string, unknown>;
+  userAgent: string;
+  userAgentData: Record<string, unknown>;
+}>;
+
+/**
+ * Envelope fields shared by every Pipelines payload.
+ *
+ * `messageId` and `timestamp` are auto-filled by `PipelinesClient` when the
+ * caller omits them; supplying them explicitly disables the auto-fill for
+ * that field on that call.
+ */
+export type PipelinesCommon = Partial<{
+  messageId: string;
+  timestamp: string; // ISO 8601
+  context: PipelinesContext;
+  integrations: Record<string, boolean>;
+}>;
+
+export type IdentifyPayload = PipelinesIdentifier &
+  PipelinesCommon & {
+    traits?: Record<string, unknown>;
+  };
+
+export type TrackPayload = PipelinesIdentifier &
+  PipelinesCommon & {
+    event: string;
+    properties?: Record<string, unknown>;
+  };
+
+export type PagePayload = PipelinesIdentifier &
+  PipelinesCommon & {
+    name?: string;
+    category?: string;
+    properties?: Record<string, unknown>;
+  };
+
+export type ScreenPayload = PipelinesIdentifier &
+  PipelinesCommon & {
+    name?: string;
+    category?: string;
+    properties?: Record<string, unknown>;
+  };
+
+export type GroupPayload = PipelinesIdentifier &
+  PipelinesCommon & {
+    groupId: string;
+    traits?: Record<string, unknown>;
+  };
+
+export type AliasPayload = PipelinesCommon & {
+  userId: string | number;
+  previousId: string | number;
+};
+
+/**
+ * A single entry in a `/batch` request. The `type` discriminator selects the
+ * payload shape and tells the Pipelines API which endpoint the entry would
+ * otherwise have been sent to.
+ */
+export type BatchItem =
+  | ({ type: 'identify' } & IdentifyPayload)
+  | ({ type: 'track' } & TrackPayload)
+  | ({ type: 'page' } & PagePayload)
+  | ({ type: 'screen' } & ScreenPayload)
+  | ({ type: 'group' } & GroupPayload)
+  | ({ type: 'alias' } & AliasPayload);

--- a/lib/regions.ts
+++ b/lib/regions.ts
@@ -10,17 +10,12 @@ export class Region {
     return typeof instance === 'object' && instance !== null && (instance as any)[REGION_BRAND] === true;
   }
 
-  // TODO(v5): make `pipelinesUrl` required and drop the fallback derivation
-  // below. Kept optional in v4.x because `Region` is exported and callers may
-  // construct it directly with the original two-argument signature.
-  constructor(trackUrl: string, apiUrl: string, pipelinesUrl?: string) {
+  constructor(trackUrl: string, apiUrl: string, pipelinesUrl: string) {
     Object.defineProperty(this, REGION_BRAND, { value: true });
     this.trackUrl = trackUrl;
     this.trackV2Url = trackUrl.replace('/api/v1', '/api/v2');
     this.apiUrl = apiUrl;
-    // Fallback: derive the CDP host from the track host, so a legacy
-    // `new Region(trackUrl, apiUrl)` call still produces a sensible value.
-    this.pipelinesUrl = pipelinesUrl ?? trackUrl.replace('track', 'cdp').replace('/api/v1', '/v1');
+    this.pipelinesUrl = pipelinesUrl;
   }
 }
 

--- a/test/pipelines.ts
+++ b/test/pipelines.ts
@@ -1,0 +1,273 @@
+import type { TestFn } from 'ava';
+import avaTest from 'ava';
+import sinon from 'sinon';
+import { PipelinesClient } from '../lib/pipelines';
+import { RegionUS, RegionEU } from '../lib/regions';
+import { version } from '../lib/version';
+import type { BatchItem } from '../lib/pipelines/payloads';
+
+type TestContext = { client: PipelinesClient };
+
+const test = avaTest as TestFn<TestContext>;
+
+const WRITE_KEY = 'wk-abc-123';
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+test.beforeEach((t) => {
+  t.context.client = new PipelinesClient(WRITE_KEY);
+});
+
+// -----------------------------------------------------------------------------
+// constructor
+// -----------------------------------------------------------------------------
+
+test('constructor sets necessary variables', (t) => {
+  t.is(t.context.client.writeKey, WRITE_KEY);
+  t.is(t.context.client.pipelinesRoot, 'https://cdp.customer.io/v1');
+  t.truthy(t.context.client.request);
+});
+
+test('constructor sets correct URL for RegionUS', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, { region: RegionUS });
+  t.is(client.pipelinesRoot, 'https://cdp.customer.io/v1');
+});
+
+test('constructor sets correct URL for RegionEU', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, { region: RegionEU });
+  t.is(client.pipelinesRoot, 'https://cdp-eu.customer.io/v1');
+});
+
+test('constructor honors a custom url override', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, { url: 'https://cdp.example.com/v1' });
+  t.is(client.pipelinesRoot, 'https://cdp.example.com/v1');
+});
+
+test('constructor uses Basic auth with the write key as username and a blank password', (t) => {
+  // Basic auth wire format: base64("<writeKey>:")
+  const expected = `Basic ${Buffer.from(`${WRITE_KEY}:`, 'utf8').toString('base64')}`;
+  t.is(t.context.client.request.auth, expected);
+});
+
+test('constructor throws when writeKey is missing', (t) => {
+  t.throws(() => new PipelinesClient(''), { message: 'writeKey is required' });
+});
+
+test('constructor throws on an invalid region', (t) => {
+  t.throws(() => new PipelinesClient(WRITE_KEY, { region: 'au' } as any), {
+    message: 'region must be one of Regions.US or Regions.EU',
+  });
+});
+
+test('constructor adds X-Strict-Mode: 1 to defaults.headers when strictMode is true', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, { strictMode: true });
+  t.is((client.defaults.headers as Record<string, string>)['X-Strict-Mode'], '1');
+});
+
+test('constructor preserves caller-supplied headers when adding X-Strict-Mode', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, {
+    strictMode: true,
+    headers: { 'X-Custom': 'yes' },
+  });
+  const headers = client.defaults.headers as Record<string, string>;
+  t.is(headers['X-Strict-Mode'], '1');
+  t.is(headers['X-Custom'], 'yes');
+});
+
+test('constructor omits X-Strict-Mode when strictMode is not set', (t) => {
+  const headers = (t.context.client.defaults.headers ?? {}) as Record<string, string>;
+  t.false('X-Strict-Mode' in headers);
+});
+
+// -----------------------------------------------------------------------------
+// envelope auto-fill
+// -----------------------------------------------------------------------------
+
+test('#identify auto-fills messageId, timestamp, and context.library', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.identify({ userId: 'u1', traits: { plan: 'pro' } });
+
+  const [url, body] = post.firstCall.args as [string, any];
+  t.is(url, 'https://cdp.customer.io/v1/identify');
+  t.regex(body.messageId, UUID_RE);
+  t.regex(body.timestamp, ISO_TIMESTAMP_RE);
+  t.deepEqual(body.context.library, { name: 'customerio-node', version });
+  t.is(body.userId, 'u1');
+  t.deepEqual(body.traits, { plan: 'pro' });
+});
+
+test('#identify preserves caller-supplied messageId, timestamp, and context.library', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.identify({
+    userId: 'u1',
+    messageId: 'caller-msg-id',
+    timestamp: '2024-01-01T00:00:00.000Z',
+    context: { library: { name: 'my-app', version: '9.9.9' } },
+  });
+
+  const [, body] = post.firstCall.args as [string, any];
+  t.is(body.messageId, 'caller-msg-id');
+  t.is(body.timestamp, '2024-01-01T00:00:00.000Z');
+  t.deepEqual(body.context.library, { name: 'my-app', version: '9.9.9' });
+});
+
+test('defaultContext from defaults merges under per-call context', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, {
+    defaultContext: { ip: '10.0.0.1', locale: 'en-US' },
+  });
+  const post = sinon.stub(client.request, 'post');
+
+  client.identify({ userId: 'u1', context: { locale: 'fr-FR' } });
+  const [, body] = post.firstCall.args as [string, any];
+
+  t.is(body.context.ip, '10.0.0.1', 'defaultContext.ip flows through');
+  t.is(body.context.locale, 'fr-FR', 'per-call context wins on conflict');
+  // The auto-filled library identifier is preserved even when the caller
+  // supplies a partial context that does not mention it.
+  t.deepEqual(body.context.library, { name: 'customerio-node', version });
+});
+
+// -----------------------------------------------------------------------------
+// method routing + validation
+// -----------------------------------------------------------------------------
+
+test('#identify validates userId or anonymousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.identify({} as any), { message: 'userId or anonymousId is required' });
+});
+
+test('#identify accepts anonymousId-only payloads', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.identify({ anonymousId: 'anon-1' });
+  t.is(post.firstCall.args[0], 'https://cdp.customer.io/v1/identify');
+  t.is((post.firstCall.args[1] as any).anonymousId, 'anon-1');
+});
+
+test('#track validates userId or anonymousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.track({ event: 'Signed Up' } as any), {
+    message: 'userId or anonymousId is required',
+  });
+});
+
+test('#track validates event is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.track({ userId: 'u1' } as any), { message: 'event is required' });
+});
+
+test('#track posts to /track with the event payload', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.track({ userId: 'u1', event: 'Signed Up', properties: { plan: 'pro' } });
+
+  const [url, body] = post.firstCall.args as [string, any];
+  t.is(url, 'https://cdp.customer.io/v1/track');
+  t.is(body.event, 'Signed Up');
+  t.deepEqual(body.properties, { plan: 'pro' });
+});
+
+test('#page validates userId or anonymousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.page({} as any), { message: 'userId or anonymousId is required' });
+});
+
+test('#page posts to /page', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.page({ userId: 'u1', name: 'Home', properties: { path: '/' } });
+  t.is(post.firstCall.args[0], 'https://cdp.customer.io/v1/page');
+});
+
+test('#screen validates userId or anonymousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.screen({} as any), { message: 'userId or anonymousId is required' });
+});
+
+test('#screen posts to /screen', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.screen({ userId: 'u1', name: 'Settings' });
+  t.is(post.firstCall.args[0], 'https://cdp.customer.io/v1/screen');
+});
+
+test('#group validates userId or anonymousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.group({ groupId: 'g1' } as any), {
+    message: 'userId or anonymousId is required',
+  });
+});
+
+test('#group validates groupId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.group({ userId: 'u1' } as any), { message: 'groupId is required' });
+});
+
+test('#group posts to /group with the groupId and traits', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.group({ userId: 'u1', groupId: 'g1', traits: { plan: 'enterprise' } });
+
+  const [url, body] = post.firstCall.args as [string, any];
+  t.is(url, 'https://cdp.customer.io/v1/group');
+  t.is(body.groupId, 'g1');
+  t.deepEqual(body.traits, { plan: 'enterprise' });
+});
+
+test('#alias validates userId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.alias({ previousId: 'p1' } as any), { message: 'userId is required' });
+});
+
+test('#alias validates previousId is required', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.alias({ userId: 'u1' } as any), { message: 'previousId is required' });
+});
+
+test('#alias posts to /alias', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.alias({ userId: 'u1', previousId: 'p1' });
+
+  const [url, body] = post.firstCall.args as [string, any];
+  t.is(url, 'https://cdp.customer.io/v1/alias');
+  t.is(body.userId, 'u1');
+  t.is(body.previousId, 'p1');
+});
+
+// -----------------------------------------------------------------------------
+// batch
+// -----------------------------------------------------------------------------
+
+test('#batch throws when items is empty', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.batch([]), { message: 'items is required' });
+});
+
+test('#batch throws when items is not an array', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.batch({} as any), { message: 'items is required' });
+});
+
+test('#batch posts to /batch, envelopes every item, and preserves the type discriminator', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const items: BatchItem[] = [
+    { type: 'identify', userId: 'u1', traits: { plan: 'pro' } },
+    { type: 'track', userId: 'u1', event: 'Signed Up' },
+    { type: 'alias', userId: 'u1', previousId: 'p1' },
+  ];
+
+  t.context.client.batch(items);
+
+  const [url, body] = post.firstCall.args as [string, any];
+  t.is(url, 'https://cdp.customer.io/v1/batch');
+  t.is(body.batch.length, 3);
+
+  for (const [i, entry] of body.batch.entries()) {
+    t.is(entry.type, items[i].type, `item ${i} preserves its type discriminator`);
+    t.regex(entry.messageId, UUID_RE, `item ${i} got an auto messageId`);
+    t.regex(entry.timestamp, ISO_TIMESTAMP_RE, `item ${i} got an auto timestamp`);
+    t.deepEqual(entry.context.library, { name: 'customerio-node', version });
+  }
+});
+
+test('#batch routes EU traffic to the EU host', (t) => {
+  const client = new PipelinesClient(WRITE_KEY, { region: RegionEU });
+  const post = sinon.stub(client.request, 'post');
+  client.batch([{ type: 'track', userId: 'u1', event: 'X' }]);
+  t.is(post.firstCall.args[0], 'https://cdp-eu.customer.io/v1/batch');
+});

--- a/test/regions.ts
+++ b/test/regions.ts
@@ -25,18 +25,12 @@ test('Region constructor accepts an explicit pipelinesUrl', (t) => {
   t.is(region.pipelinesUrl, 'https://cdp.example.com/v1');
 });
 
-test('Region constructor derives pipelinesUrl from trackUrl when omitted (legacy two-arg form)', (t) => {
-  // Older callers constructing Region directly with the original two-argument
-  // signature must continue to work — pipelinesUrl is derived deterministically
-  // from the track host. TODO(v5): remove this fallback and make the third
-  // argument required.
-  const region = new Region('https://track.customer.io/api/v1', 'https://api.customer.io/v1');
-
-  t.is(region.pipelinesUrl, 'https://cdp.customer.io/v1');
-});
-
 test('Region instances are recognized via the Symbol.for brand check', (t) => {
-  const region = new Region('https://track.example.com/api/v1', 'https://api.example.com/v1');
+  const region = new Region(
+    'https://track.example.com/api/v1',
+    'https://api.example.com/v1',
+    'https://cdp.example.com/v1',
+  );
 
   t.true(region instanceof Region);
 });


### PR DESCRIPTION
This adds a new pipelines client, using the OpenAPI spec from the docs site as a source of truth to implement all currently available methods.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New public API surface and a breaking Region constructor change for anyone instantiating Region manually; ingestion/auth behavior is customer-data relevant but well covered by tests and docs.
> 
> **Overview**
> Adds **`PipelinesClient`** for the Segment-style Pipelines API (separate CDP hosts, Pipelines write key auth), with **`identify`**, **`track`**, **`page`**, **`screen`**, **`group`**, **`alias`**, and **`batch`**, plus camelCase payload types, per-request envelope defaults (`messageId`, `timestamp`, `context.library`), and options for **`strictMode`**, **`defaultContext`**, region/`url` overrides.
> 
> **Breaking:** **`Region`** now requires an explicit third **`pipelinesUrl`** (no more deriving CDP from the track URL); **`RegionUS`** / **`RegionEU`** ship fixed `cdp*.customer.io/v1` values. The package exports the client, README/changelog/example coverage, and a large **`test/pipelines.ts`** suite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79684ed6e10524dbce999855cd3673cfe2108791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->