### PR TITLE
Convert ESLint config from CJS to ESM

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,5 @@
-const tsParser = require('@typescript-eslint/parser');
-const tsPlugin = require('@typescript-eslint/eslint-plugin');
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
 
 const typeAwareRules = {
   '@typescript-eslint/consistent-type-imports': 'error',
@@ -7,7 +7,7 @@ const typeAwareRules = {
   '@typescript-eslint/no-floating-promises': 'error',
 };
 
-module.exports = [
+export default [
   {
     ignores: ['coverage/**', 'dist/**', 'examples/**', 'node_modules/**'],
   },
@@ -17,7 +17,7 @@ module.exports = [
       parser: tsParser,
       parserOptions: {
         project: './tsconfig.eslint.json',
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     plugins: {
@@ -37,7 +37,7 @@ module.exports = [
       parser: tsParser,
       parserOptions: {
         project: './tsconfig.eslint.json',
-        tsconfigRootDir: __dirname,
+        tsconfigRootDir: import.meta.dirname,
       },
     },
     plugins: {


### PR DESCRIPTION
## Summary
- Rename `eslint.config.js` to `eslint.config.mjs` to use ES module syntax
- Replace `require()` with `import`, `module.exports` with `export default`
- Replace `__dirname` with `import.meta.dirname` (available since Node 21.2; this repo requires Node >=22)

ESLint auto-discovers `eslint.config.mjs`, so lint-staged and all scripts continue to work unchanged.

## Test plan
- [x] `npm run build` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (162 tests, 100% coverage)
- [x] lint-staged config unchanged — ESLint auto-discovers `.mjs` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to ESLint config format; no runtime or library behavior changes.
> 
> **Overview**
> Migrates the flat ESLint config to **ES modules** (`eslint.config.mjs`): `require`/`module.exports` become `import`/`export default`, and both `tsconfigRootDir` settings use **`import.meta.dirname`** instead of `__dirname` (aligned with the repo’s Node **≥22** engine).
> 
> Lint rules, file globs, and ignores are unchanged; **`npm run lint`** and lint-staged still invoke ESLint, which picks up the `.mjs` config automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20479ea3e2a8728a54a8bdbe2d21cd8492957db3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->