### PR TITLE
Type fetch options correctly

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,5 +1,4 @@
-import type { RequestOptions } from 'https';
-import type { BearerAuth, RequestData, RetryOptions } from './request';
+import type { BearerAuth, RequestData, RequestDefaults, RetryOptions } from './request';
 import Request from './request';
 import { Region, RegionUS } from './regions';
 import {
@@ -13,7 +12,7 @@ import { isEmpty, isIdentifierType, MissingParamError } from './utils';
 import type { Filter } from './types';
 import { IdentifierType } from './types';
 
-type APIDefaults = RequestOptions & { region: Region; url?: string; retry?: Partial<RetryOptions> };
+type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
 
@@ -72,7 +71,10 @@ export class APIClient {
 
     this.appKey = appKey;
     this.defaults = { ...defaults, region: defaults.region || RegionUS };
-    this.request = new Request(this.appKey, this.defaults);
+    // `region`/`url` are SDK concerns (they select the host); strip them so the
+    // transport receives only fetch init. `retry` is handled by `Request`.
+    const { region: _region, url: _url, ...requestDefaults } = this.defaults;
+    this.request = new Request(this.appKey, requestDefaults);
 
     this.apiRoot = this.defaults.url ? this.defaults.url : this.defaults.region.apiUrl;
   }

--- a/lib/pipelines.ts
+++ b/lib/pipelines.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'crypto';
-import type { RequestOptions } from 'https';
 import Request from './request';
-import type { RetryOptions } from './request';
+import type { RequestDefaults, RetryOptions } from './request';
 import { Region, RegionUS } from './regions';
 import { isEmpty, MissingParamError } from './utils';
 import { version } from './version';
@@ -17,7 +16,7 @@ import type {
   TrackPayload,
 } from './pipelines/payloads';
 
-export type PipelinesDefaults = RequestOptions & {
+export type PipelinesDefaults = RequestDefaults & {
   region: Region;
   /** Overrides the region-derived host. Useful for testing against a proxy. */
   url?: string;
@@ -68,7 +67,18 @@ export class PipelinesClient {
     // into `siteid` and leave `apikey` empty so the encoded credential is
     // exactly `base64(writeKey:)`. The field names are an internal artifact
     // and never leak through to the public API.
-    this.request = new Request({ siteid: writeKey, apikey: '' }, this.defaults);
+    //
+    // Strip the SDK-only keys; the remainder (the computed `headers`, plus any
+    // `dispatcher`/`keepalive`/`timeout`/retry the caller supplied) is fetch
+    // init for the transport.
+    const {
+      region: _region,
+      url: _url,
+      strictMode: _strictMode,
+      defaultContext: _defaultContext,
+      ...requestDefaults
+    } = this.defaults;
+    this.request = new Request({ siteid: writeKey, apikey: '' }, requestDefaults);
 
     this.pipelinesRoot = this.defaults.url ? this.defaults.url : this.defaults.region.pipelinesUrl;
 

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -1,22 +1,42 @@
-import type { RequestOptions } from 'https';
 import { CustomerIORequestError } from './utils';
 import { version } from './version';
 
-export type BasicAuth = {
+export interface BasicAuth {
   apikey: string;
   siteid: string;
-};
+}
 
 export type BearerAuth = string;
 
 export type RequestAuth = BasicAuth | BearerAuth;
 export type RequestData = Record<string, any> | undefined;
-export type RequestHandlerOptions = {
-  method: RequestOptions['method'];
-  uri: string;
-  headers: RequestOptions['headers'];
-  body?: string | null;
+
+/**
+ * Options forwarded to the underlying `fetch` call.
+ *
+ * This is the native fetch `RequestInit`, minus the fields the SDK owns and
+ * sets itself (`method`, `body`, `signal`, `redirect`), plus a convenience
+ * `timeout`. `headers` is narrowed to a plain record since that's the only
+ * shape the SDK ever merges.
+ *
+ * Use `dispatcher` (an undici `Agent` / `ProxyAgent`) for HTTP(S) proxies,
+ * custom TLS (mTLS or a private CA), or connection keep-alive — it is the
+ * fetch-era replacement for the `https.Agent` knob that the old transport
+ * accepted but `fetch` cannot honor.
+ */
+export type RequestDefaults = Omit<RequestInit, 'method' | 'body' | 'signal' | 'redirect' | 'headers'> & {
+  /** Per-request headers merged into every call. SDK headers always win on conflict. */
+  headers?: Record<string, string>;
+  /** Request timeout in milliseconds. Defaults to `10000`. */
+  timeout?: number;
 };
+
+export interface RequestHandlerOptions {
+  method: string;
+  uri: string;
+  headers: Record<string, string | number>;
+  body?: string | null;
+}
 export interface PushRequestData {
   delivery_id?: string;
   device_id?: string;
@@ -64,10 +84,10 @@ export default class CIORequest {
   siteid?: BasicAuth['siteid'];
   appKey?: BearerAuth;
   auth: string;
-  defaults: RequestOptions;
+  defaults: RequestDefaults;
   retry: RetryOptions;
 
-  constructor(auth: RequestAuth, defaults?: RequestOptions & { retry?: Partial<RetryOptions> }) {
+  constructor(auth: RequestAuth, defaults?: RequestDefaults & { retry?: Partial<RetryOptions> }) {
     if (typeof auth === 'object') {
       this.apikey = auth.apikey;
       this.siteid = auth.siteid;
@@ -78,8 +98,8 @@ export default class CIORequest {
       this.auth = `Bearer ${this.appKey}`;
     }
 
-    // `retry` is kept off `this.defaults` so the latter stays a pure
-    // `RequestOptions` bag that gets forwarded to the HTTP layer untouched.
+    // `retry` is kept off `this.defaults` so the latter stays a pure fetch
+    // `RequestInit` bag (plus `timeout`) that is forwarded to `fetch` untouched.
     const { retry, ...requestDefaults } = defaults ?? {};
     this.defaults = {
       timeout: TIMEOUT,
@@ -88,15 +108,13 @@ export default class CIORequest {
     this.retry = { ...DEFAULT_RETRY, ...retry };
   }
 
-  options(uri: string, method: RequestOptions['method'], data?: RequestData): RequestHandlerOptions {
+  options(uri: string, method: string, data?: RequestData): RequestHandlerOptions {
     const body = data ? JSON.stringify(data) : null;
     // Per-client custom headers (e.g. `X-Strict-Mode` for the Pipelines
     // client) can be supplied via `defaults.headers`. They're merged in
     // first so the standard headers below always win and cannot be
-    // clobbered. The cast is needed because `OutgoingHttpHeaders` has both
-    // named properties (with narrower types like `string | string[]`) and
-    // an index signature — spreading it into a literal that mixes those
-    // values with our own `number`-typed `Content-Length` confuses tsc.
+    // clobbered. The widening cast lets us mix our own `number`-typed
+    // `Content-Length` into the same record as the string-valued headers.
     const customHeaders = (this.defaults.headers ?? {}) as Record<string, string | number>;
     const headers: Record<string, string | number> = {
       ...customHeaders,
@@ -119,12 +137,19 @@ export default class CIORequest {
     //   - Timeout → `DOMException("TimeoutError")` from `AbortSignal.timeout`.
     // These are intentionally not translated; callers should inspect `name`,
     // `cause`, and `cause.code` rather than relying on the legacy error shapes.
+    //
+    // User-supplied fetch init (`dispatcher`, `keepalive`, …) is forwarded via
+    // the spread. `headers` and `timeout` are handled specially, and the
+    // SDK-owned fields (`method`, `body`, `redirect`, `signal`) are applied
+    // after the spread so a caller can never override them.
+    const { headers: _headers, timeout, ...fetchInit } = this.defaults;
     const response = await fetch(uri, {
+      ...fetchInit,
       method,
       headers: headers as Record<string, string>,
       body,
       redirect: 'manual',
-      signal: AbortSignal.timeout(this.defaults.timeout as number),
+      signal: AbortSignal.timeout(timeout as number),
     });
 
     const statusCode = response.status;
@@ -148,7 +173,7 @@ export default class CIORequest {
         const newHostname = new URL(newURI).hostname;
         if (!newHostname.endsWith('.customer.io') && headers && 'Authorization' in headers) {
           const { Authorization: _stripped, ...rest } = headers as Record<string, unknown>;
-          redirectHeaders = rest as RequestOptions['headers'];
+          redirectHeaders = rest as Record<string, string | number>;
         }
       } catch {
         // No need to do anything if the URL is malformed or relative

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -1,11 +1,10 @@
-import type { RequestOptions } from 'https';
-import type { BasicAuth, RequestData, PushRequestData, RetryOptions } from './request';
+import type { BasicAuth, RequestData, PushRequestData, RequestDefaults, RetryOptions } from './request';
 import Request from './request';
 import { Region, RegionUS } from './regions';
 import { isEmpty, isIdentifierType, MissingParamError } from './utils';
 import type { IdentifierType } from './types';
 
-type TrackDefaults = RequestOptions & { region: Region; url?: string; retry?: Partial<RetryOptions> };
+type TrackDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 export type BatchOperation = Record<string, any>;
 
@@ -25,7 +24,10 @@ export class TrackClient {
     this.siteid = siteid;
     this.apikey = apikey;
     this.defaults = { ...defaults, region: defaults.region || RegionUS };
-    this.request = new Request({ siteid: this.siteid, apikey: this.apikey }, this.defaults);
+    // `region`/`url` are SDK concerns (they select the host); strip them so the
+    // transport receives only fetch init. `retry` is handled by `Request`.
+    const { region: _region, url: _url, ...requestDefaults } = this.defaults;
+    this.request = new Request({ siteid: this.siteid, apikey: this.apikey }, requestDefaults);
 
     this.trackRoot = this.defaults.url ? this.defaults.url : this.defaults.region.trackUrl;
     this.trackV2Root = this.defaults.url

--- a/test/request.ts
+++ b/test/request.ts
@@ -208,6 +208,47 @@ test.serial('#handler makes a request and passes the uri and init correctly', as
   }
 });
 
+test.serial('#handler forwards a custom dispatcher from defaults to fetch', async (t) => {
+  // A dispatcher is the fetch-era replacement for `https.Agent` (proxy / mTLS /
+  // keep-alive). We only care that whatever the caller passed reaches fetch.
+  const dispatcher = { sentinel: 'test-dispatcher' };
+  const req = new Request({ siteid, apikey }, { timeout: 5000, dispatcher: dispatcher as never });
+  createMockRequest(t.context.fetchStub, 200, {});
+
+  await req.handler(req.options(uri, 'GET'));
+
+  const init = t.context.fetchStub.getCall(0).args[1] as RequestInit;
+  t.is((init as { dispatcher?: unknown }).dispatcher, dispatcher);
+});
+
+test.serial('#handler forwards keepalive from defaults to fetch', async (t) => {
+  const req = new Request({ siteid, apikey }, { timeout: 5000, keepalive: true });
+  createMockRequest(t.context.fetchStub, 200, {});
+
+  await req.handler(req.options(uri, 'GET'));
+
+  const init = t.context.fetchStub.getCall(0).args[1] as RequestInit;
+  t.is(init.keepalive, true);
+});
+
+test.serial('#handler does not let defaults override the SDK-owned fetch fields', async (t) => {
+  // `method`/`body`/`redirect`/`signal` are owned by the SDK. Even if a caller
+  // smuggles them in via defaults (they're omitted from the type), the
+  // transport's own values must win.
+  const req = new Request(
+    { siteid, apikey },
+    { timeout: 5000, redirect: 'follow', method: 'PATCH', body: 'nope' } as never,
+  );
+  createMockRequest(t.context.fetchStub, 200, {});
+
+  await req.handler(req.options(uri, 'GET'));
+
+  const init = t.context.fetchStub.getCall(0).args[1] as RequestInit;
+  t.is(init.method, 'GET');
+  t.is(init.redirect, 'manual');
+  t.is(init.body, null);
+});
+
 test.serial('#handler makes a request and rejects with an error on failure', async (t) => {
   const customOptions = {
     ...baseOptions,


### PR DESCRIPTION
This fixes the types used for the request options to use the node types over the https types, which aren't valid with `fetch`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared HTTP layer used by every client; incorrect passthrough could affect proxies/TLS, though behavior is covered by new tests and mostly corrects types.
> 
> **Overview**
> Replaces **`https.RequestOptions`** with a fetch-aligned **`RequestDefaults`** type (`RequestInit` minus SDK-owned fields, plus **`timeout`** and plain **`headers`**), so client options like **`dispatcher`** and **`keepalive`** are valid for Node’s **`fetch`** transport.
> 
> **`CIORequest`** now spreads caller defaults into **`fetch`** (after stripping **`headers`**/**`timeout`**) while **`method`**, **`body`**, **`redirect`**, and **`signal`** always win. **`TrackClient`**, **`APIClient`**, and **`PipelinesClient`** strip SDK-only keys (**`region`**/**`url`**, and for Pipelines **`strictMode`**/**`defaultContext`**) before constructing the inner **`Request`**, so those settings don’t leak into fetch init.
> 
> Adds request tests that **`dispatcher`**/**`keepalive`** reach **`fetch`** and that smuggled **`method`**/**`body`**/**`redirect`** cannot override the SDK.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02f7ce636a91cbb71a4606cbf811d12bd1a2ecab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->