### PR TITLE
CDP-6131: make triggerBroadcast data and recipients optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,13 @@ api.triggerBroadcast(1, { name: "foo" }, { emails: ["example@emails.com"], email
 
 [You can learn more about the available recipient fields here](https://customer.io/docs/api/#operation/triggerBroadcast).
 
+Both `data` and `recipients` are optional. Omitting `recipients` sends the broadcast to its configured recipients. Note that the parameters are positional: to pass `recipients` without `data`, pass `undefined` for `data` — passing the recipient selector as the second argument would send it as liquid data instead.
+
+```javascript
+api.triggerBroadcast(1); // broadcast's configured recipients
+api.triggerBroadcast(1, undefined, { emails: ["example@emails.com"], email_ignore_missing: true });
+```
+
 #### Options
 
 - **id**: String or number (required)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -221,24 +221,31 @@ export class APIClient {
    * Otherwise the entire `recipients` object is forwarded verbatim alongside
    * `data` (use this for segment-based recipients).
    *
+   * Both `data` and `recipients` are optional; omitting `recipients` sends the
+   * broadcast to its configured recipients.
+   *
    * @param broadcastId The broadcast (campaign) id.
    * @param data Liquid `data` payload made available to the broadcast template.
    * @param recipients Recipient selector. See above.
    * @returns The parsed JSON response body.
    */
-  triggerBroadcast(broadcastId: string | number, data: RequestData, recipients: Recipients) {
-    let payload = {};
-    let customRecipientField = (
-      Object.keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS) as BroadcastsAllowedRecipientFieldsKeys[]
-    ).find((field) => recipients[field]);
+  triggerBroadcast(broadcastId: string | number, data?: RequestData, recipients?: Recipients) {
+    let payload: Record<string, unknown> = {};
 
-    if (customRecipientField) {
-      payload = Object.assign({ data }, filterRecipientsDataForField(recipients, customRecipientField));
-    } else {
-      payload = {
-        data,
-        recipients,
-      };
+    if (data && Object.keys(data).length > 0) {
+      payload.data = data;
+    }
+
+    if (recipients && Object.keys(recipients).length > 0) {
+      let customRecipientField = (
+        Object.keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS) as BroadcastsAllowedRecipientFieldsKeys[]
+      ).find((field) => recipients[field]);
+
+      if (customRecipientField) {
+        payload = Object.assign(payload, filterRecipientsDataForField(recipients, customRecipientField));
+      } else {
+        payload.recipients = recipients;
+      }
     }
 
     return this.request.post(`${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers`, payload);

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -224,6 +224,12 @@ export class APIClient {
    * Both `data` and `recipients` are optional; omitting `recipients` sends the
    * broadcast to its configured recipients.
    *
+   * Note that the parameters are positional: to pass `recipients` without
+   * `data`, pass `undefined` for `data` — e.g.
+   * `triggerBroadcast(1, undefined, { emails: ['user@example.com'] })`.
+   * Passing the recipient selector as the second argument would send it as
+   * liquid `data` and trigger the broadcast's configured recipients instead.
+   *
    * @param broadcastId The broadcast (campaign) id.
    * @param data Liquid `data` payload made available to the broadcast template.
    * @param recipients Recipient selector. See above.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -238,11 +238,11 @@ export class APIClient {
   triggerBroadcast(broadcastId: string | number, data?: RequestData, recipients?: Recipients) {
     let payload: Record<string, unknown> = {};
 
-    if (data && Object.keys(data).length > 0) {
+    if (data != null && Object.keys(data).length > 0) {
       payload.data = data;
     }
 
-    if (recipients && Object.keys(recipients).length > 0) {
+    if (recipients != null && Object.keys(recipients).length > 0) {
       let customRecipientField = (
         Object.keys(BROADCASTS_ALLOWED_RECIPIENT_FIELDS) as BroadcastsAllowedRecipientFieldsKeys[]
       ).find((field) => recipients[field]);

--- a/test/api.ts
+++ b/test/api.ts
@@ -406,6 +406,17 @@ test('#triggerBroadcast works with data and no recipients', (t) => {
   );
 });
 
+test('#triggerBroadcast works with recipients and no data', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1, undefined, { emails: ['test@email.com'], email_ignore_missing: true });
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/campaigns/1/triggers`, {
+      emails: ['test@email.com'],
+      email_ignore_missing: true,
+    }),
+  );
+});
+
 test('#triggerBroadcast omits empty data and recipients objects', (t) => {
   sinon.stub(t.context.client.request, 'post');
   t.context.client.triggerBroadcast(1, {}, {});

--- a/test/api.ts
+++ b/test/api.ts
@@ -390,6 +390,28 @@ test('#triggerBroadcast discards extraneous fields', (t) => {
   );
 });
 
+test('#triggerBroadcast works with broadcastId only', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1);
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/campaigns/1/triggers`, {}));
+});
+
+test('#triggerBroadcast works with data and no recipients', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1, { type: 'data' });
+  t.truthy(
+    (t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/campaigns/1/triggers`, {
+      data: { type: 'data' },
+    }),
+  );
+});
+
+test('#triggerBroadcast omits empty data and recipients objects', (t) => {
+  sinon.stub(t.context.client.request, 'post');
+  t.context.client.triggerBroadcast(1, {}, {});
+  t.truthy((t.context.client.request.post as SinonStub).calledWith(`${RegionUS.apiUrl}/campaigns/1/triggers`, {}));
+});
+
 test('#listExports: success', (t) => {
   sinon.stub(t.context.client.request, 'get');
   t.context.client.listExports();


### PR DESCRIPTION
## Summary

The [README](https://github.com/customerio/customerio-node#apitriggerbroadcastcampaign_id-data-recipients) documents both `data` and `recipients` as optional for `api.triggerBroadcast()`, but the signature declared them as required positional arguments. Two failure modes:

1. `api.triggerBroadcast(4)` — `recipients` is `undefined`, so `recipients[field]` throws a **TypeError**
2. `api.triggerBroadcast(4, {}, {})` — the empty `recipients` object is forwarded to the API, which rejects it with a **422** (`empty recipients filter is not valid`)

Both params are now optional, and empty/omitted `data`/`recipients` are left out of the payload, so triggering a broadcast with just its id sends to the broadcast's configured recipients as documented.

## Test plan

- New ava cases: broadcastId only, data without recipients, and empty `{}` objects for both
- `npm test` — 253 tests pass, coverage stays at 100%
- `npm run lint` and `npm run build` clean

Fixes [CDP-6131](https://linear.app/customerio/issue/CDP-6131)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted SDK fix for broadcast triggers with new tests; behavior change only affects previously broken or invalid call patterns.
> 
> **Overview**
> **`APIClient.triggerBroadcast`** now treats **`data`** and **`recipients`** as optional and only adds them to the POST body when they are present and non-empty. Calling with just a broadcast id sends `{}`, so the broadcast uses its configured recipients instead of throwing on missing `recipients` or getting a 422 from an empty `recipients` filter.
> 
> Docs and JSDoc explain that both arguments are optional and that **`recipients` without `data`** must use **`undefined`** for the second positional argument. Tests cover id-only, data-only, recipients-only, and `{}`/`{}` omission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6546597b549ca381ac8bdaab9fc6e6eb38708be6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->