### PR TITLE
Add AI policy

### DIFF
--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,38 @@
+# AI Policy
+
+Using AI (i.e., LLMs) as tools for coding is welcome. A high bar is held for
+all contributions to this project. Moreover, the project maintainers remain
+responsible for any code that is published as part of a release. Contributors
+are expected to be responsible for any code they publish.
+
+**AI should not be used to generate comments when communicating with
+maintainers**. Comments are expected to be written by humans. Comments that are
+believed to be written by AI may be hidden without notice.
+
+If you are opening an issue, you should be able to describe the problem in your
+own words.
+
+If you are opening a pull request, you are expected to be able to explain the
+proposed changes in your own words. This includes the pull request body and
+responses to questions. **Do not copy responses from the AI when replying to
+questions from maintainers.**
+
+This project requires a human in the loop who understands the work produced by
+AI. **Autonomous agents are not allowed to be used for contributing to this
+project**. Pull requests that appear in violation of this will be closed,
+perhaps without notice.
+
+If you wish to include context from an interaction with AI in your comments, it
+must be in a quote block (e.g., using `>`) and disclosed as such. It must be
+accompanied by human commentary explaining the relevance and implications of
+the context. Do not share long snippets.
+
+AI is useful when communicating as a non-native English speaker. If you are
+using AI to edit your comments for this purpose, please take the time to ensure
+it reflects your own voice and ideas. If using AI for translation, we recommend
+writing in your native language and including the AI translation in a quote
+block.
+
+This policy was adapted from [uv's AI policy].
+
+[uv's AI policy]: https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md


### PR DESCRIPTION
Adds an AI policy borrowed from [ripgrep](https://github.com/BurntSushi/ripgrep/blob/master/AI_POLICY.md), which was borrowed from [uv](https://github.com/astral-sh/.github/blob/c5187e200db51bfe11d56e13053d29bd3793fdd8/AI_POLICY.md).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime, security, or data-handling code changes.
> 
> **Overview**
> Adds a new **`AI_POLICY.md`** documenting how contributors may use LLMs and how maintainers expect human-authored communication.
> 
> The policy welcomes AI-assisted coding but keeps maintainers and contributors responsible for shipped code. It bans AI-generated maintainer-facing comments and autonomous agents, requires contributors to explain issues and PRs in their own words, and sets rules for quoting AI context and for non-native speakers using AI for editing or translation. It credits adaptation from uv’s AI policy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2452dece6c20102d785d3977df3a7d6584029daa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->