### PR TITLE
Prepare v5.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.0.1]
+
+#### Fixed
+
+- **`triggerBroadcast` now treats `data` and `recipients` as optional**, matching the documented API. Calling with only a broadcast id no longer throws a `TypeError`, and empty `data` / `recipients` objects are omitted from the request payload instead of producing a 422 (`empty recipients filter is not valid`) from the API — so `api.triggerBroadcast(id)` sends the broadcast to its configured recipients. The parameters are positional: to pass `recipients` without `data`, use `triggerBroadcast(id, undefined, recipients)`. ([#220](https://github.com/customerio/customerio-node/pull/220))
+
 ## [5.0.0]
 
 The internals of `lib/request.ts` have been rewritten on top of native `fetch` (no more `https.request`), and a new `PipelinesClient` has been added for the Pipelines API. The existing `TrackClient` / `APIClient` method surface is unchanged. Most users will not need to update any code; the breaking changes are documented below.

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.0.0';
+export const version = '5.0.1';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-node",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-node",
-      "version": "5.0.0",
+      "version": "5.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
This updates the version and changelog for the v5.0.1 release.

Patch release containing the `triggerBroadcast` optional-params fix (#220, CDP-6131). Version bumped via `npm version patch` (package.json, package-lock.json, lib/version.ts) and a 5.0.1 changelog entry added — same shape as #216.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata and version strings only; no runtime code changes in this diff.
> 
> **Overview**
> **Prepares the v5.0.1 patch release** by bumping the package version from `5.0.0` to `5.0.1` in `package.json`, `package-lock.json`, and `lib/version.ts`.
> 
> Adds a **5.0.1** section to `CHANGELOG.md` that documents the shipped fix: **`triggerBroadcast`** treats **`data`** and **`recipients`** as optional (aligned with the API), avoids `TypeError` when only a broadcast id is passed, and omits empty payload fields so the API does not return 422 for empty recipient filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f719cc7dc6e4d3c42b38609a280a6925c22a3b4b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->