### PR TITLE
Backfill missing track API methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,97 @@ cio.batch([
 
 - **operations**: Array of operation objects (required, non-empty)
 
+### cio.entity(operation)
+
+Send a single self-describing operation to the [v2 entity endpoint](https://customer.io/docs/api/track/#operation/entity). This is the singular counterpart to `cio.batch` — `operation` is shaped like one element of a `batch` array.
+
+```javascript
+cio.entity({
+  type: "person",
+  action: "identify",
+  identifiers: { id: "1" },
+  attributes: { plan: "pro" },
+});
+```
+
+#### Options
+
+- **operation**: A single operation object (required, non-empty)
+
+### cio.addCustomersToSegment(segmentId, customerIds, idType)
+
+Add people to a manual segment.
+
+```javascript
+cio.addCustomersToSegment(7, ["1", "2"]);
+cio.addCustomersToSegment(7, ["a@example.com"], IdentifierType.Email);
+```
+
+#### Options
+
+- **segmentId**: The manual segment's id (required)
+- **customerIds**: Array of 1–1000 identifiers, matching `idType` (required, non-empty)
+- **idType**: One of `id`, `email`, or `cio_id` (optional; the API defaults to `id`)
+
+### cio.removeCustomersFromSegment(segmentId, customerIds, idType)
+
+Remove people from a manual segment. Same arguments as `addCustomersToSegment`.
+
+```javascript
+cio.removeCustomersFromSegment(7, ["1", "2"]);
+```
+
+### cio.submitForm(formId, data)
+
+Submit a [form](https://customer.io/docs/api/track/#operation/submitForm) on behalf of a person. `data` holds the submitted form fields and must contain exactly one identifier (`email` or `id`) so the submission can be attributed to a person.
+
+```javascript
+cio.submitForm("signup", { email: "a@example.com", plan: "pro" });
+```
+
+#### Options
+
+- **formId**: The form's id (required)
+- **data**: The submitted form fields, including the identifier (required, non-empty)
+
+### cio.reportMetric(data)
+
+Report a delivery metric (open, click, bounce, etc.) for any channel to the [metrics endpoint](https://customer.io/docs/api/track/#operation/metrics). Unlike `cio.trackPush` (push only), this works for email, SMS, push, in-app, Slack, and webhook deliveries.
+
+```javascript
+cio.reportMetric({
+  delivery_id: "RPILAgUBcRhIBqSfeiIwdIYJKxTY",
+  metric: "opened",
+  timestamp: 1613063089,
+});
+```
+
+#### Options
+
+- **data**: Metric payload. `delivery_id` is required; `metric`, `timestamp`, `recipient`, `reason`, and `href` are optional. Valid `metric` values depend on the delivery's channel.
+
+### cio.getAccountRegion()
+
+Look up the data region (US or EU) your account belongs to.
+
+```javascript
+cio.getAccountRegion();
+```
+
+### cio.unsubscribe(deliveryId, unsubscribe)
+
+Custom [unsubscribe handling](https://customer.io/docs/api/track/#operation/unsubscribe) for a specific delivery. Sets (or clears) the recipient's `unsubscribed` attribute and attributes the change to the delivery.
+
+```javascript
+cio.unsubscribe("RPILAgUBcRhIBqSfeiIwdIYJKxTY");
+cio.unsubscribe("RPILAgUBcRhIBqSfeiIwdIYJKxTY", false); // resubscribe
+```
+
+#### Options
+
+- **deliveryId**: The `CIO-Delivery-ID` of the message (required)
+- **unsubscribe**: `true` (default) to unsubscribe, `false` to resubscribe
+
 ### Using Promises
 
 All calls to the library will return a native promise, allowing you to chain calls as such:

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,7 @@ export * from './lib/regions';
 export * from './lib/types';
 export { CustomerIORequestError, MissingParamError } from './lib/utils';
 export type { ResponseLike } from './lib/utils';
-export type { RequestDefaults, RetryOptions } from './lib/request';
+export type { RequestDefaults, RetryOptions, PushRequestData, MetricRequestData } from './lib/request';
 export type {
   Identifiers,
   SendEmailRequestOptions,

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -45,6 +45,28 @@ export interface PushRequestData {
 }
 
 /**
+ * Payload for {@link TrackClient.reportMetric} — a delivery metric reported to
+ * the Track API `/metrics` endpoint. The valid `metric` values depend on the
+ * channel of the delivery (e.g. email supports `delivered`/`opened`/`clicked`/
+ * `bounced`; push supports `delivered`/`opened`/`converted`), so `metric` is
+ * left as a loose string rather than a per-channel union.
+ */
+export interface MetricRequestData {
+  /** The `CIO-Delivery-ID` of the message the metric applies to. */
+  delivery_id?: string;
+  /** The metric/event being reported. Channel-specific. */
+  metric?: string;
+  /** The unix timestamp (seconds) when the event occurred. */
+  timestamp?: number;
+  /** The recipient address/token the delivery was sent to. */
+  recipient?: string;
+  /** Reason for a `bounced`/`dropped` metric, when applicable. */
+  reason?: string;
+  /** The link that was clicked, for `clicked` metrics. */
+  href?: string;
+}
+
+/**
  * Per-request retry policy. Retries are stateless and happen at the HTTP layer,
  * so every client (`TrackClient`, `APIClient`, `PipelinesClient`) inherits them.
  */

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -1,4 +1,11 @@
-import type { BasicAuth, RequestData, PushRequestData, RequestDefaults, RetryOptions } from './request';
+import type {
+  BasicAuth,
+  RequestData,
+  PushRequestData,
+  MetricRequestData,
+  RequestDefaults,
+  RetryOptions,
+} from './request';
 import Request from './request';
 import { Region, RegionUS } from './regions';
 import { isEmpty, isIdentifierType, MissingParamError } from './utils';
@@ -335,5 +342,175 @@ export class TrackClient {
         [secondaryIdType]: secondaryId,
       },
     });
+  }
+
+  /**
+   * Look up the data region your account belongs to.
+   *
+   * Confirms whether your workspace is hosted in the US or EU region and
+   * returns the base URL your other Track API calls should use.
+   *
+   * @returns The parsed JSON response body (`{ url, region, environment_id }`).
+   */
+  getAccountRegion() {
+    return this.request.get(`${this.trackRoot}/accounts/region`);
+  }
+
+  /**
+   * Send a single self-describing Track operation to the v2 entity endpoint.
+   *
+   * This is the singular counterpart to {@link TrackClient.batch}: `operation`
+   * is the same shape as one element of a `batch` array — an identify, track,
+   * delete, merge, add/remove relationship, add/remove device, etc.
+   *
+   * @param operation A single batch-style operation object.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `operation` is not a non-empty object.
+   */
+  entity(operation: BatchOperation) {
+    if (operation == null || typeof operation !== 'object' || Array.isArray(operation)) {
+      throw new MissingParamError('operation');
+    }
+
+    if (Object.keys(operation).length === 0) {
+      throw new MissingParamError('operation');
+    }
+
+    return this.request.post(`${this.trackV2Root}/entity`, operation);
+  }
+
+  /**
+   * Add people to a manual segment.
+   *
+   * @param segmentId The manual segment's id.
+   * @param customerIds The identifiers of the people to add (1–1000). The value
+   *   type must match `idType`; entries that don't match are ignored by the API.
+   * @param idType Which identifier kind the values in `customerIds` are. When
+   *   omitted, the API uses its default (`id`).
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `segmentId` is empty or `customerIds` is not a non-empty array.
+   * @throws {Error} If `idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  addCustomersToSegment(segmentId: string | number, customerIds: Array<string | number>, idType?: IdentifierType) {
+    if (isEmpty(segmentId)) {
+      throw new MissingParamError('segmentId');
+    }
+
+    if (!Array.isArray(customerIds) || customerIds.length === 0) {
+      throw new MissingParamError('customerIds');
+    }
+
+    if (idType != null && !isIdentifierType(idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = idType ? `?id_type=${idType}` : '';
+
+    return this.request.post(
+      `${this.trackRoot}/segments/${encodeURIComponent(segmentId)}/add_customers${query}`,
+      { ids: customerIds },
+    );
+  }
+
+  /**
+   * Remove people from a manual segment.
+   *
+   * @param segmentId The manual segment's id.
+   * @param customerIds The identifiers of the people to remove (1–1000). The value
+   *   type must match `idType`; entries that don't match are ignored by the API.
+   * @param idType Which identifier kind the values in `customerIds` are. When
+   *   omitted, the API uses its default (`id`).
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `segmentId` is empty or `customerIds` is not a non-empty array.
+   * @throws {Error} If `idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  removeCustomersFromSegment(segmentId: string | number, customerIds: Array<string | number>, idType?: IdentifierType) {
+    if (isEmpty(segmentId)) {
+      throw new MissingParamError('segmentId');
+    }
+
+    if (!Array.isArray(customerIds) || customerIds.length === 0) {
+      throw new MissingParamError('customerIds');
+    }
+
+    if (idType != null && !isIdentifierType(idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = idType ? `?id_type=${idType}` : '';
+
+    return this.request.post(
+      `${this.trackRoot}/segments/${encodeURIComponent(segmentId)}/remove_customers${query}`,
+      { ids: customerIds },
+    );
+  }
+
+  /**
+   * Submit a form on behalf of a person.
+   *
+   * The `data` object holds the submitted form fields. It must contain exactly
+   * one identifier (`email` or `id`, depending on your workspace settings) so
+   * the submission can be attributed to a person; the person is created if they
+   * don't already exist.
+   *
+   * @param formId The form's id.
+   * @param data The submitted form fields, including the identifier.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `formId` is empty or `data` is not a non-empty object.
+   */
+  submitForm(formId: string | number, data: RequestData = {}) {
+    if (isEmpty(formId)) {
+      throw new MissingParamError('formId');
+    }
+
+    if (data == null || typeof data !== 'object' || Object.keys(data).length === 0) {
+      throw new MissingParamError('data');
+    }
+
+    return this.request.post(`${this.trackRoot}/forms/${encodeURIComponent(formId)}/submit`, { data });
+  }
+
+  /**
+   * Report a delivery metric (open, click, bounce, etc.) back to Customer.io.
+   *
+   * Unlike {@link TrackClient.trackPush} (which targets push deliveries only via
+   * `/push/events`), this reports metrics for any channel — email, SMS, push,
+   * in-app, Slack, or webhook — to the `/metrics` endpoint. The valid `metric`
+   * values depend on the delivery's channel.
+   *
+   * @param data Metric payload. `delivery_id` is required; optionally include
+   *   `metric`, `timestamp`, `recipient`, `reason`, and `href`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `data.delivery_id` is empty.
+   */
+  reportMetric(data: MetricRequestData = {}) {
+    if (isEmpty(data.delivery_id)) {
+      throw new MissingParamError('data.delivery_id');
+    }
+
+    return this.request.post(`${this.trackRoot}/metrics`, data);
+  }
+
+  /**
+   * Custom unsubscribe handling for a specific delivery.
+   *
+   * Sets (or clears) the recipient's `unsubscribed` attribute and attributes the
+   * change to the given delivery. This endpoint lives at the host root (not under
+   * `/api/v1`) and does not require authentication — the `deliveryId` itself is
+   * the secret.
+   *
+   * @param deliveryId The `CIO-Delivery-ID` of the message to unsubscribe from.
+   * @param unsubscribe When `true` (default) the person is unsubscribed; `false` resubscribes them.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `deliveryId` is empty.
+   */
+  unsubscribe(deliveryId: string | number, unsubscribe: boolean = true) {
+    if (isEmpty(deliveryId)) {
+      throw new MissingParamError('deliveryId');
+    }
+
+    const host = this.trackRoot.replace('/api/v1', '');
+
+    return this.request.post(`${host}/unsubscribe/${encodeURIComponent(deliveryId)}`, { unsubscribe });
   }
 }

--- a/lib/track.ts
+++ b/lib/track.ts
@@ -255,7 +255,7 @@ export class TrackClient {
       device: {
         id: device_id,
         platform,
-        ...(last_used ? { last_used } : {}),
+        ...(last_used != null ? { last_used } : {}),
         ...(Object.keys(attributes).length && { attributes }),
       },
     });

--- a/test/integration/live.env.example
+++ b/test/integration/live.env.example
@@ -37,3 +37,9 @@ CIO_TEST_INAPP_TRANSACTIONAL_ID=
 CIO_TEST_INBOX_TRANSACTIONAL_ID=
 CIO_TEST_BROADCAST_ID=
 CIO_TEST_NEWSLETTER_ID=
+# Manual segment id for add/removeCustomersFromSegment
+CIO_TEST_MANUAL_SEGMENT_ID=
+# Form id for submitForm
+CIO_TEST_FORM_ID=
+# CIO-Delivery-ID for reportMetric + unsubscribe
+CIO_TEST_DELIVERY_ID=

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -19,6 +19,9 @@
  *   CIO_TEST_SMS_RECIPIENT           E.164 phone number for sendSMS
  *   CIO_TEST_PUSH_TRANSACTIONAL_ID   transactional_message_id for sendPush
  *   CIO_TEST_PUSH_DEVICE_ID          device id for sendPush + addDevice
+ *   CIO_TEST_MANUAL_SEGMENT_ID       manual segment id for add/removeCustomersFromSegment
+ *   CIO_TEST_FORM_ID                 form id for submitForm
+ *   CIO_TEST_DELIVERY_ID             CIO-Delivery-ID for reportMetric + unsubscribe
  *
  * Profile lifecycle: one throwaway customer per run, id = `sdk-live-${uuid()}`.
  * Cleanup is best-effort; the dedicated workspace tolerates orphans.
@@ -70,6 +73,12 @@ liveTest('getCustomersByEmail returns the expected shape for an unknown address'
 liveTest('listExports resolves', async (t) => {
   const result = (await api!.listExports()) as { exports: unknown };
   t.true('exports' in result);
+});
+
+liveTest('getAccountRegion reports the workspace region', async (t) => {
+  const result = (await track!.getAccountRegion()) as { url?: string; region?: string };
+  t.truthy(result.url);
+  t.truthy(result.region);
 });
 
 // 2. Idempotent writes. Order matters: later tests assume the profile exists.
@@ -127,6 +136,16 @@ liveTest('batch sends a mixed batch', async (t) => {
       name: 'sdk_live_batch_event',
     },
   ]);
+  t.pass();
+});
+
+liveTest('entity sends a single identify operation', async (t) => {
+  await track!.entity({
+    type: 'person',
+    action: 'identify',
+    identifiers: { id: customerId },
+    attributes: { entity_at: new Date().toISOString() },
+  });
   t.pass();
 });
 
@@ -214,7 +233,36 @@ needs('CIO_TEST_NEWSLETTER_ID')('createDeliveriesExport queues an export', async
   t.truthy(result.export);
 });
 
-// 5. Destructive cleanup. Runs last; failures here are warnings on a dedicated
+// 5. Manual segments, forms, and metrics. Gated on workspace-specific IDs.
+
+needs('CIO_TEST_MANUAL_SEGMENT_ID')('add + removeCustomersFromSegment round-trip', async (t) => {
+  const segmentId = Number(process.env.CIO_TEST_MANUAL_SEGMENT_ID!);
+  await track!.addCustomersToSegment(segmentId, [customerId], IdentifierType.Id);
+  await track!.removeCustomersFromSegment(segmentId, [customerId], IdentifierType.Id);
+  t.pass();
+});
+
+needs('CIO_TEST_FORM_ID')('submitForm submits a form for the profile', async (t) => {
+  await track!.submitForm(process.env.CIO_TEST_FORM_ID!, { email: customerEmail, source: 'sdk-live-test' });
+  t.pass();
+});
+
+needs('CIO_TEST_DELIVERY_ID')('reportMetric reports a delivery metric', async (t) => {
+  await track!.reportMetric({
+    delivery_id: process.env.CIO_TEST_DELIVERY_ID!,
+    metric: 'opened',
+    timestamp: Math.floor(Date.now() / 1000),
+  });
+  t.pass();
+});
+
+needs('CIO_TEST_DELIVERY_ID')('unsubscribe toggles the unsubscribe state for a delivery', async (t) => {
+  await track!.unsubscribe(process.env.CIO_TEST_DELIVERY_ID!, true);
+  await track!.unsubscribe(process.env.CIO_TEST_DELIVERY_ID!, false);
+  t.pass();
+});
+
+// 6. Destructive cleanup. Runs last; failures here are warnings on a dedicated
 // test workspace.
 
 liveTest('deleteDevice removes the device from the profile', async (t) => {

--- a/test/track.ts
+++ b/test/track.ts
@@ -343,3 +343,173 @@ test('#batch throws when operations is not an array', (t) => {
   t.throws(() => (t.context.client.batch as any)(undefined), { message: 'operations is required' });
   t.throws(() => (t.context.client.batch as any)({ batch: [] }), { message: 'operations is required' });
 });
+
+test('#getAccountRegion gets the accounts/region endpoint', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+
+  t.context.client.getAccountRegion();
+
+  t.true(get.calledOnce);
+  t.true(get.calledWith('https://track.customer.io/api/v1/accounts/region'));
+});
+
+test('#getAccountRegion uses the EU root when constructed with RegionEU', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionEU });
+  const get = sinon.stub(client.request, 'get');
+
+  client.getAccountRegion();
+
+  t.true(get.calledWith('https://track-eu.customer.io/api/v1/accounts/region'));
+});
+
+test('#entity posts the operation to /api/v2/entity', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const operation = { type: 'person', identifiers: { id: '1' }, action: 'identify', attributes: { plan: 'pro' } };
+
+  t.context.client.entity(operation);
+
+  t.true(post.calledOnce);
+  t.true(post.calledWith('https://track.customer.io/api/v2/entity', operation));
+});
+
+test('#entity uses the EU v2 root when constructed with RegionEU', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionEU });
+  const post = sinon.stub(client.request, 'post');
+  const operation = { type: 'person', identifiers: { id: '1' }, action: 'identify' };
+
+  client.entity(operation);
+
+  t.true(post.calledWith('https://track-eu.customer.io/api/v2/entity', operation));
+});
+
+test('#entity throws when the operation is not a non-empty object', (t) => {
+  t.throws(() => (t.context.client.entity as any)(undefined), { message: 'operation is required' });
+  t.throws(() => (t.context.client.entity as any)('nope'), { message: 'operation is required' });
+  t.throws(() => (t.context.client.entity as any)([]), { message: 'operation is required' });
+  t.throws(() => t.context.client.entity({}), { message: 'operation is required' });
+});
+
+test('#addCustomersToSegment posts ids to the add_customers endpoint', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.addCustomersToSegment(7, ['1', '2']);
+
+  t.true(post.calledOnce);
+  t.true(
+    post.calledWith('https://track.customer.io/api/v1/segments/7/add_customers', { ids: ['1', '2'] }),
+  );
+});
+
+test('#addCustomersToSegment appends id_type when provided', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.addCustomersToSegment(7, ['a@example.com'], IdentifierType.Email);
+
+  t.true(
+    post.calledWith('https://track.customer.io/api/v1/segments/7/add_customers?id_type=email', {
+      ids: ['a@example.com'],
+    }),
+  );
+});
+
+test('#addCustomersToSegment validates its inputs', (t) => {
+  t.throws(() => t.context.client.addCustomersToSegment('', ['1']), { message: 'segmentId is required' });
+  t.throws(() => t.context.client.addCustomersToSegment(7, []), { message: 'customerIds is required' });
+  t.throws(() => (t.context.client.addCustomersToSegment as any)(7, '1'), { message: 'customerIds is required' });
+  t.throws(() => t.context.client.addCustomersToSegment(7, ['1'], 'nope' as any), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+});
+
+test('#removeCustomersFromSegment posts ids to the remove_customers endpoint', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.removeCustomersFromSegment(7, ['1', '2'], IdentifierType.Id);
+
+  t.true(post.calledOnce);
+  t.true(
+    post.calledWith('https://track.customer.io/api/v1/segments/7/remove_customers?id_type=id', {
+      ids: ['1', '2'],
+    }),
+  );
+});
+
+test('#removeCustomersFromSegment omits id_type when not provided', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.removeCustomersFromSegment(7, ['1', '2']);
+
+  t.true(
+    post.calledWith('https://track.customer.io/api/v1/segments/7/remove_customers', { ids: ['1', '2'] }),
+  );
+});
+
+test('#removeCustomersFromSegment validates its inputs', (t) => {
+  t.throws(() => t.context.client.removeCustomersFromSegment('', ['1']), { message: 'segmentId is required' });
+  t.throws(() => t.context.client.removeCustomersFromSegment(7, []), { message: 'customerIds is required' });
+  t.throws(() => t.context.client.removeCustomersFromSegment(7, ['1'], 'nope' as any), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+});
+
+test('#submitForm posts the data wrapped under a data key', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.submitForm('signup', { email: 'a@example.com', plan: 'pro' });
+
+  t.true(post.calledOnce);
+  t.true(
+    post.calledWith('https://track.customer.io/api/v1/forms/signup/submit', {
+      data: { email: 'a@example.com', plan: 'pro' },
+    }),
+  );
+});
+
+test('#submitForm validates its inputs', (t) => {
+  t.throws(() => t.context.client.submitForm('', { email: 'a@example.com' }), { message: 'formId is required' });
+  t.throws(() => t.context.client.submitForm('signup', {}), { message: 'data is required' });
+  t.throws(() => (t.context.client.submitForm as any)('signup', null), { message: 'data is required' });
+  t.throws(() => (t.context.client.submitForm as any)('signup', 'nope'), { message: 'data is required' });
+  t.throws(() => (t.context.client.submitForm as any)('signup'), { message: 'data is required' });
+});
+
+test('#reportMetric posts to the /metrics endpoint', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const data = { delivery_id: 'abc', metric: 'opened', timestamp: 1613063089 };
+
+  t.context.client.reportMetric(data);
+
+  t.true(post.calledOnce);
+  t.true(post.calledWith('https://track.customer.io/api/v1/metrics', data));
+});
+
+test('#reportMetric throws when delivery_id is missing', (t) => {
+  t.throws(() => t.context.client.reportMetric(), { message: 'data.delivery_id is required' });
+  t.throws(() => t.context.client.reportMetric({ metric: 'opened' }), {
+    message: 'data.delivery_id is required',
+  });
+});
+
+test('#unsubscribe posts to the root-level /unsubscribe path', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+
+  t.context.client.unsubscribe('RPILAgUBcRhIBqSfeiIwdIYJKxTY');
+
+  t.true(post.calledOnce);
+  t.true(
+    post.calledWith('https://track.customer.io/unsubscribe/RPILAgUBcRhIBqSfeiIwdIYJKxTY', { unsubscribe: true }),
+  );
+});
+
+test('#unsubscribe forwards a false flag and uses the EU host', (t) => {
+  let client = new TrackClient('123', 'abc', { region: RegionEU });
+  const post = sinon.stub(client.request, 'post');
+
+  client.unsubscribe('abc', false);
+
+  t.true(post.calledWith('https://track-eu.customer.io/unsubscribe/abc', { unsubscribe: false }));
+});
+
+test('#unsubscribe throws when deliveryId is empty', (t) => {
+  t.throws(() => t.context.client.unsubscribe(''), { message: 'deliveryId is required' });
+});

--- a/test/track.ts
+++ b/test/track.ts
@@ -243,6 +243,20 @@ test('#addDevice works with an empty data parameter', (t) => {
   );
 });
 
+test('#addDevice preserves a last_used timestamp of 0', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.context.client.addDevice(1, '123', 'ios', { last_used: 0 });
+  t.true(
+    put.calledWith(`${RegionUS.trackUrl}/customers/1/devices`, {
+      device: {
+        id: '123',
+        platform: 'ios',
+        last_used: 0,
+      },
+    }),
+  );
+});
+
 test('#deleteDevice works', (t) => {
   sinon.stub(t.context.client.request, 'destroy');
   t.throws(() => (t.context.client.deleteDevice as any)(''), { message: 'customerId is required' });


### PR DESCRIPTION
This uses claude 🤖 and the [Track API OpenAPI spec](https://docs.customer.io/files/journeys-track.json) to backfill all missing methods in the track API for customer.io. This also makes any fixes needed from our existing methods to be inline with the OpenAPI spec.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive SDK surface with tests; `unsubscribe`, segment membership, and `reportMetric` can change person attributes or delivery telemetry if callers pass wrong IDs, but behavior mirrors documented Track API endpoints.
> 
> **Overview**
> **`TrackClient`** gains wrappers aligned with the Track OpenAPI spec: **`getAccountRegion`**, **`entity`** (single v2 operation), **`addCustomersToSegment`** / **`removeCustomersFromSegment`**, **`submitForm`**, **`reportMetric`** (all-channel metrics via `/metrics`), and **`unsubscribe`** (host-root path, optional resubscribe). A new **`MetricRequestData`** type is exported from the package entrypoint.
> 
> **`addDevice`** now includes **`last_used: 0`** in the payload (previously dropped because `0` was treated as falsy). README documents the new methods; unit and optional live integration tests cover URLs, validation, US/EU roots, and gated env vars for segments, forms, and delivery IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9aa9d769f0ab05c4f9e056b2dbfbc40b31e6e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->