### PR TITLE
Deploy Typedoc API reference to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: docs
+
+# Build the Typedoc API reference and publish it to GitHub Pages.
+# Runs on every push to main; can also be triggered manually.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Grant the token the permissions the Pages deploy needs. `id-token` is
+# required by actions/deploy-pages for OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent Pages deployment. Don't cancel an in-progress run,
+# so a deploy always finishes cleanly.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: npm
+
+      - run: npm ci
+
+      - name: build typedoc
+        # Outputs to ./typedoc (see `out` in typedoc.json).
+        run: npm run docs
+
+      - name: upload pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: typedoc
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ return cio.track(customerId, {
 
 ## API reference
 
-Method-level documentation for each client lives in the [`docs/`](./docs) folder:
+Method-level documentation for each client lives in the [`docs/`](https://github.com/customerio/customerio-node/tree/main/docs) folder:
 
 - [Track API](./docs/track.md) — `TrackClient`
 - [App API](./docs/app.md) — `APIClient`

--- a/typedoc.json
+++ b/typedoc.json
@@ -4,10 +4,11 @@
   "out": "typedoc",
   "name": "customerio-node",
   "readme": "README.md",
+  "projectDocuments": ["docs/track.md", "docs/app.md", "docs/pipelines.md"],
   "excludePrivate": true,
   "excludeInternal": true,
   "excludeExternals": true,
-  "githubPages": false,
+  "githubPages": true,
   "categorizeByGroup": true,
   "sort": ["source-order"],
   "navigation": {
@@ -29,7 +30,6 @@
     "SendInAppRequestOptionalOptions",
     "PipelinesIdentifier",
     "RequestData",
-    "PushRequestData",
     "default"
   ]
 }


### PR DESCRIPTION
Adds a docs workflow that builds the Typedoc reference (`npm run docs`) and publishes it to GitHub Pages on every push to `main` (and via manual dispatch), using the official `actions/upload-pages-artifact` + `actions/deploy-pages` flow.

Typedoc config updates for a coherent published site:
- `githubPages`: true so a `.nojekyll` file is emitted (the output uses underscore-prefixed paths that Jekyll would otherwise drop).
- `projectDocuments`: include the hand-written `docs/{track,app,pipelines}.md` guides so they render alongside the generated API reference.
- Drop the stale `PushRequestData` entry from `intentionallyNotExported` (it is exported as of #224) and switch the README `docs/` folder link to an absolute URL, so the docs build is warning-free.

NOTE: requires enabling GitHub Pages for the repo with Source = GitHub Actions.

AI assisted 🤖 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and CI-only changes; no runtime SDK behavior. Requires enabling GitHub Pages with Actions as the source.
> 
> **Overview**
> Adds a **GitHub Actions** workflow (`.github/workflows/docs.yml`) that runs `npm run docs` on every push to `main` (and on manual dispatch), uploads the `typedoc` output, and deploys it with the official Pages artifact + `deploy-pages` flow (OIDC permissions, single concurrent `pages` deploy group).
> 
> **Typedoc** is tuned for the published site: `githubPages: true` (`.nojekyll` for underscore paths), `projectDocuments` for the hand-written `docs/track.md`, `docs/app.md`, and `docs/pipelines.md`, and removal of stale `PushRequestData` from `intentionallyNotExported`. The README API section now links the `docs/` folder with an absolute GitHub URL.
> 
> **Repo setup:** GitHub Pages must use **Source = GitHub Actions**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1a2d86101b923f4f1116df3342e8ff790ea20ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->