### PR TITLE
Add App API customer & object methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -150,6 +150,163 @@ api.getAttributes("1", IdentifierType.ID);
 - **id**: Customer identifier, String or number (required)
 - **id_type**: One of the ID types - "id" / "email" / "cio_id" (default is "id")
 
+### api.getCustomerActivities(customerId, options)
+
+Look up a person's activities (events, attribute changes, message activity, etc.).
+
+```javascript
+api.getCustomerActivities("1", { type: "event", name: "purchase", limit: 50 });
+```
+
+#### Options
+
+- **customerId**: Customer identifier, String or number (required)
+- **options**: Object (optional)
+  - _idType_: One of "id" / "email" / "cio_id" (defaults to "id")
+  - _start_: Pagination cursor from a previous page's `next`
+  - _limit_: Maximum number of results
+  - _type_: Filter to a single [activity type](https://docs.customer.io/api/app/#operation/listCustomerActivities)
+  - _name_: Filter to activities with this name
+
+### api.getCustomerMessages(customerId, options)
+
+Look up messages sent to a person.
+
+```javascript
+api.getCustomerMessages("1", { start_ts: 1719792000, end_ts: 1719878400 });
+```
+
+#### Options
+
+- **customerId**: Customer identifier, String or number (required)
+- **options**: Object (optional) — `idType`, `start`, `limit`, and `start_ts` / `end_ts` Unix timestamp bounds
+
+### api.getCustomerRelationships(customerId, options)
+
+Look up a person's relationships to objects.
+
+```javascript
+api.getCustomerRelationships("1", { limit: 20 });
+```
+
+#### Options
+
+- **customerId**: Customer identifier, String or number (required)
+- **options**: Object (optional) — `start`, `limit`
+
+### api.getCustomerSegments(customerId, idType)
+
+Look up the segments a person belongs to.
+
+```javascript
+api.getCustomerSegments("1", IdentifierType.Id);
+```
+
+#### Options
+
+- **customerId**: Customer identifier, String or number (required)
+- **idType**: One of "id" / "email" / "cio_id" (default is "id")
+
+### api.getCustomerSubscriptionPreferences(customerId, options)
+
+Look up a person's subscription (topic) preferences.
+
+```javascript
+api.getCustomerSubscriptionPreferences("1", { language: "es-ES" });
+```
+
+#### Options
+
+- **customerId**: Customer identifier, String or number (required)
+- **options**: Object (optional) — `idType`, and `language` (an IETF language tag used to localize topic names)
+
+### api.searchCustomers(filter, options)
+
+Search for people matching a filter expression.
+
+```javascript
+api.searchCustomers({ and: [{ segment: { id: 7 } }] }, { limit: 100 });
+```
+
+#### Options
+
+- **filter**: A segment/attribute filter expression (and/or/not) (required)
+- **options**: Object (optional) — `start`, `limit`
+
+### api.getCustomersAttributes(ids)
+
+Look up attributes and devices for a set of people in one request.
+
+```javascript
+api.getCustomersAttributes(["1", "2", "3"]);
+```
+
+#### Options
+
+- **ids**: A non-empty array of customer identifiers (required)
+
+### api.getObjectAttributes(objectTypeId, objectId, idType)
+
+Get an object's attributes.
+
+```javascript
+api.getObjectAttributes(1, "acme", "object_id");
+```
+
+#### Options
+
+- **objectTypeId**: The object type's numeric id (required)
+- **objectId**: The object's identifier value (required)
+- **idType**: One of "object_id" / "cio_object_id" (defaults to "object_id")
+
+### api.getObjectRelationships(objectTypeId, objectId, options)
+
+Get an object's relationships to people.
+
+```javascript
+api.getObjectRelationships(1, "acme", { limit: 20 });
+```
+
+#### Options
+
+- **objectTypeId**: The object type's numeric id (required)
+- **objectId**: The object's identifier value (required)
+- **options**: Object (optional) — `idType` ("object_id" / "cio_object_id"), `start`, `limit`
+
+### api.findObjects(objectTypeId, filter, options)
+
+Find objects of a given type matching a filter expression.
+
+```javascript
+api.findObjects(1, { and: [{ attribute: { field: "plan", operator: "eq", value: "pro" } }] });
+```
+
+#### Options
+
+- **objectTypeId**: The object type's numeric id (required)
+- **filter**: A filter expression (and/or/not) (required)
+- **options**: Object (optional) — `start`, `limit`
+
+### api.listObjectTypes()
+
+List the object types defined in your workspace.
+
+```javascript
+api.listObjectTypes();
+```
+
+### api.listActivities(options)
+
+List activities across your workspace.
+
+```javascript
+api.listActivities({ type: "event", customerId: "1", idType: IdentifierType.Id });
+```
+
+#### Options
+
+- **options**: Object (optional) — `start`, `limit`, `type`, `name`, `deleted`, `customerId`, `idType`
+
 ### api.listExports()
 
 Return a list of your exports. Exports are point-in-time people or campaign metrics.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,9 +8,66 @@ import {
   SendInboxMessageRequest,
   SendInAppRequest,
 } from './api/requests';
-import { isEmpty, isIdentifierType, MissingParamError } from './utils';
+import { isEmpty, isIdentifierType, buildQueryString, MissingParamError } from './utils';
 import type { Filter } from './types';
 import { IdentifierType } from './types';
+
+/** Which identifier kind the values in an object endpoint refer to. */
+export type ObjectIdType = 'object_id' | 'cio_object_id';
+
+/** Cursor pagination shared by most App API list endpoints. */
+export type PaginationOptions = {
+  /** Pagination cursor returned as `next` by a previous page. */
+  start?: string;
+  /** Maximum number of results to return in the page. */
+  limit?: number;
+};
+
+/** Options for {@link APIClient.getCustomerActivities}. */
+export type CustomerActivitiesOptions = PaginationOptions & {
+  /** Which identifier kind `customerId` is. Defaults to the API's default (`id`). */
+  idType?: IdentifierType;
+  /** Filter to a single activity type (e.g. `attribute_change`, `event`). */
+  type?: string;
+  /** Filter to activities with this name (e.g. the event name). */
+  name?: string;
+};
+
+/** Options for {@link APIClient.getCustomerMessages}. */
+export type CustomerMessagesOptions = PaginationOptions & {
+  idType?: IdentifierType;
+  /** Only include messages after this Unix timestamp (seconds). */
+  start_ts?: number;
+  /** Only include messages before this Unix timestamp (seconds). */
+  end_ts?: number;
+};
+
+/** Options for {@link APIClient.getCustomerSubscriptionPreferences}. */
+export type CustomerSubscriptionPreferencesOptions = {
+  idType?: IdentifierType;
+  /** IETF language tag used to localize topic names in the response. */
+  language?: string;
+};
+
+/** Options for {@link APIClient.getObjectRelationships}. */
+export type ObjectRelationshipsOptions = PaginationOptions & {
+  /** Which identifier kind `objectId` is. Defaults to the API's default (`object_id`). */
+  idType?: ObjectIdType;
+};
+
+/** Options for {@link APIClient.listActivities}. */
+export type ListActivitiesOptions = PaginationOptions & {
+  /** Filter to a single activity type. */
+  type?: string;
+  /** Filter to activities with this name. */
+  name?: string;
+  /** Include activities from deleted people. */
+  deleted?: boolean;
+  /** Scope to a single person's activities. */
+  customerId?: string | number;
+  /** Which identifier kind `customerId` is. */
+  idType?: IdentifierType;
+};
 
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
@@ -348,6 +405,277 @@ export class APIClient {
     }
 
     return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(id)}/attributes?id_type=${idType}`);
+  }
+
+  /**
+   * Look up a person's activities (events, attribute changes, message activity, …).
+   *
+   * @param customerId The person's identifier value.
+   * @param options Optional filters/pagination. See {@link CustomerActivitiesOptions}.
+   * @returns The parsed JSON response body (`{ activities: [...], next }`).
+   * @throws {MissingParamError} If `customerId` is empty.
+   * @throws {Error} If `options.idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  getCustomerActivities(customerId: string | number, options: CustomerActivitiesOptions = {}) {
+    if (isEmpty(customerId)) {
+      throw new MissingParamError('customerId');
+    }
+
+    if (options.idType !== undefined && !isIdentifierType(options.idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = buildQueryString({
+      id_type: options.idType,
+      start: options.start,
+      limit: options.limit,
+      type: options.type,
+      name: options.name,
+    });
+
+    return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(customerId)}/activities${query}`);
+  }
+
+  /**
+   * Look up messages sent to a person.
+   *
+   * @param customerId The person's identifier value.
+   * @param options Optional filters/pagination. See {@link CustomerMessagesOptions}.
+   * @returns The parsed JSON response body (`{ messages: [...], next }`).
+   * @throws {MissingParamError} If `customerId` is empty.
+   * @throws {Error} If `options.idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  getCustomerMessages(customerId: string | number, options: CustomerMessagesOptions = {}) {
+    if (isEmpty(customerId)) {
+      throw new MissingParamError('customerId');
+    }
+
+    if (options.idType !== undefined && !isIdentifierType(options.idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = buildQueryString({
+      id_type: options.idType,
+      start: options.start,
+      limit: options.limit,
+      start_ts: options.start_ts,
+      end_ts: options.end_ts,
+    });
+
+    return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(customerId)}/messages${query}`);
+  }
+
+  /**
+   * Look up a person's relationships to objects.
+   *
+   * @param customerId The person's identifier value.
+   * @param options Optional pagination. See {@link PaginationOptions}.
+   * @returns The parsed JSON response body (`{ identifiers: [...], relationships: [...], next }`).
+   * @throws {MissingParamError} If `customerId` is empty.
+   */
+  getCustomerRelationships(customerId: string | number, options: PaginationOptions = {}) {
+    if (isEmpty(customerId)) {
+      throw new MissingParamError('customerId');
+    }
+
+    const query = buildQueryString({ start: options.start, limit: options.limit });
+
+    return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(customerId)}/relationships${query}`);
+  }
+
+  /**
+   * Look up the segments a person belongs to.
+   *
+   * @param customerId The person's identifier value.
+   * @param idType Which identifier kind `customerId` is. Defaults to {@link IdentifierType.Id}.
+   * @returns The parsed JSON response body (`{ segments: [...] }`).
+   * @throws {MissingParamError} If `customerId` is empty.
+   * @throws {Error} If `idType` is not a valid {@link IdentifierType}.
+   */
+  getCustomerSegments(customerId: string | number, idType: IdentifierType = IdentifierType.Id) {
+    if (isEmpty(customerId)) {
+      throw new MissingParamError('customerId');
+    }
+
+    if (!isIdentifierType(idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = buildQueryString({ id_type: idType });
+
+    return this.request.get(`${this.apiRoot}/customers/${encodeURIComponent(customerId)}/segments${query}`);
+  }
+
+  /**
+   * Look up a person's subscription (topic) preferences.
+   *
+   * @param customerId The person's identifier value.
+   * @param options Optional identifier kind and localization. See {@link CustomerSubscriptionPreferencesOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `customerId` is empty.
+   * @throws {Error} If `options.idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  getCustomerSubscriptionPreferences(
+    customerId: string | number,
+    options: CustomerSubscriptionPreferencesOptions = {},
+  ) {
+    if (isEmpty(customerId)) {
+      throw new MissingParamError('customerId');
+    }
+
+    if (options.idType !== undefined && !isIdentifierType(options.idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = buildQueryString({ id_type: options.idType, language: options.language });
+
+    return this.request.get(
+      `${this.apiRoot}/customers/${encodeURIComponent(customerId)}/subscription_preferences${query}`,
+    );
+  }
+
+  /**
+   * Search for people matching a filter.
+   *
+   * @param filter A segment/attribute filter expression (and/or/not). See {@link Filter}.
+   * @param options Optional pagination. See {@link PaginationOptions}.
+   * @returns The parsed JSON response body (`{ identifiers: [...], ids: [...], next }`).
+   * @throws {MissingParamError} If `filter` is `null` or `undefined`.
+   */
+  searchCustomers(filter: Filter, options: PaginationOptions = {}) {
+    if (filter == null) {
+      throw new MissingParamError('filter');
+    }
+
+    const query = buildQueryString({ start: options.start, limit: options.limit });
+
+    return this.request.post(`${this.apiRoot}/customers${query}`, { filter });
+  }
+
+  /**
+   * Look up attributes and devices for a set of people in one request.
+   *
+   * @param ids The identifiers of the people to look up (non-empty).
+   * @returns The parsed JSON response body (`{ customers: [...] }`).
+   * @throws {MissingParamError} If `ids` is not a non-empty array.
+   */
+  getCustomersAttributes(ids: Array<string | number>) {
+    if (!Array.isArray(ids) || ids.length === 0) {
+      throw new MissingParamError('ids');
+    }
+
+    return this.request.post(`${this.apiRoot}/customers/attributes`, { ids });
+  }
+
+  /**
+   * Get an object's attributes.
+   *
+   * @param objectTypeId The object type's numeric id.
+   * @param objectId The object's identifier value.
+   * @param idType Which identifier kind `objectId` is (`object_id` or `cio_object_id`).
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `objectTypeId` or `objectId` is empty.
+   */
+  getObjectAttributes(objectTypeId: string | number, objectId: string | number, idType?: ObjectIdType) {
+    if (isEmpty(objectTypeId)) {
+      throw new MissingParamError('objectTypeId');
+    }
+
+    if (isEmpty(objectId)) {
+      throw new MissingParamError('objectId');
+    }
+
+    const query = buildQueryString({ id_type: idType });
+
+    return this.request.get(
+      `${this.apiRoot}/objects/${encodeURIComponent(objectTypeId)}/${encodeURIComponent(objectId)}/attributes${query}`,
+    );
+  }
+
+  /**
+   * Get an object's relationships to people.
+   *
+   * @param objectTypeId The object type's numeric id.
+   * @param objectId The object's identifier value.
+   * @param options Optional identifier kind and pagination. See {@link ObjectRelationshipsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `objectTypeId` or `objectId` is empty.
+   */
+  getObjectRelationships(
+    objectTypeId: string | number,
+    objectId: string | number,
+    options: ObjectRelationshipsOptions = {},
+  ) {
+    if (isEmpty(objectTypeId)) {
+      throw new MissingParamError('objectTypeId');
+    }
+
+    if (isEmpty(objectId)) {
+      throw new MissingParamError('objectId');
+    }
+
+    const query = buildQueryString({ id_type: options.idType, start: options.start, limit: options.limit });
+
+    return this.request.get(
+      `${this.apiRoot}/objects/${encodeURIComponent(objectTypeId)}/${encodeURIComponent(objectId)}/relationships${query}`,
+    );
+  }
+
+  /**
+   * Find objects of a given type matching a filter.
+   *
+   * @param objectTypeId The object type's numeric id.
+   * @param filter A filter expression (and/or/not). See {@link Filter}.
+   * @param options Optional pagination. See {@link PaginationOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `objectTypeId` is empty or `filter` is `null`/`undefined`.
+   */
+  findObjects(objectTypeId: string | number, filter: Filter, options: PaginationOptions = {}) {
+    if (isEmpty(objectTypeId)) {
+      throw new MissingParamError('objectTypeId');
+    }
+
+    if (filter == null) {
+      throw new MissingParamError('filter');
+    }
+
+    const query = buildQueryString({ start: options.start, limit: options.limit });
+
+    return this.request.post(`${this.apiRoot}/objects${query}`, { object_type_id: objectTypeId, filter });
+  }
+
+  /**
+   * List the object types defined in your workspace.
+   *
+   * @returns The parsed JSON response body (`{ types: [...] }`).
+   */
+  listObjectTypes() {
+    return this.request.get(`${this.apiRoot}/object_types`);
+  }
+
+  /**
+   * List activities across your workspace.
+   *
+   * @param options Optional filters/pagination. See {@link ListActivitiesOptions}.
+   * @returns The parsed JSON response body (`{ activities: [...], next }`).
+   * @throws {Error} If `options.idType` is provided and is not a valid {@link IdentifierType}.
+   */
+  listActivities(options: ListActivitiesOptions = {}) {
+    if (options.idType !== undefined && !isIdentifierType(options.idType)) {
+      throw new Error('idType must be one of "id", "cio_id", or "email"');
+    }
+
+    const query = buildQueryString({
+      start: options.start,
+      limit: options.limit,
+      type: options.type,
+      name: options.name,
+      deleted: options.deleted,
+      customer_id: options.customerId,
+      id_type: options.idType,
+    });
+
+    return this.request.get(`${this.apiRoot}/activities${query}`);
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -8,7 +8,7 @@ import {
   SendInboxMessageRequest,
   SendInAppRequest,
 } from './api/requests';
-import { isEmpty, isIdentifierType, buildQueryString, MissingParamError } from './utils';
+import { isEmpty, isIdentifierType, isObjectIdType, buildQueryString, MissingParamError } from './utils';
 import type { Filter } from './types';
 import { IdentifierType } from './types';
 
@@ -585,6 +585,10 @@ export class APIClient {
       throw new MissingParamError('objectId');
     }
 
+    if (idType !== undefined && !isObjectIdType(idType)) {
+      throw new Error('idType must be one of "object_id" or "cio_object_id"');
+    }
+
     const query = buildQueryString({ id_type: idType });
 
     return this.request.get(
@@ -614,6 +618,10 @@ export class APIClient {
       throw new MissingParamError('objectId');
     }
 
+    if (options.idType !== undefined && !isObjectIdType(options.idType)) {
+      throw new Error('idType must be one of "object_id" or "cio_object_id"');
+    }
+
     const query = buildQueryString({ id_type: options.idType, start: options.start, limit: options.limit });
 
     return this.request.get(
@@ -625,12 +633,19 @@ export class APIClient {
    * Find objects of a given type matching a filter.
    *
    * @param objectTypeId The object type's numeric id.
-   * @param filter A filter expression (and/or/not). See {@link Filter}.
+   * @param filter A filter expression (and/or/not).
    * @param options Optional pagination. See {@link PaginationOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `objectTypeId` is empty or `filter` is `null`/`undefined`.
+   *
+   * @remarks
+   * The object filter schema differs from the audience {@link Filter} (it uses
+   * `object_attribute` conditions with a `type_id` and has no `segment`). A
+   * dedicated `ObjectFilter` type (plus top-level `not` support for both
+   * filters) is tracked as a follow-up; for now `filter` is typed loosely as
+   * `Record<string, any>` to avoid implying the audience shape is accepted.
    */
-  findObjects(objectTypeId: string | number, filter: Filter, options: PaginationOptions = {}) {
+  findObjects(objectTypeId: string | number, filter: Record<string, any>, options: PaginationOptions = {}) {
     if (isEmpty(objectTypeId)) {
       throw new MissingParamError('objectTypeId');
     }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -33,7 +33,7 @@ export const buildQueryString = (params: Record<string, string | number | boolea
   const parts: string[] = [];
 
   for (const [key, value] of Object.entries(params)) {
-    if (value === null || value === undefined) {
+    if (value === null || value === undefined || value === '') {
       continue;
     }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,6 +13,15 @@ export const isIdentifierType = (value: unknown) => {
 };
 
 /**
+ * Returns `true` if `value` is a valid object identifier kind (`object_id` or
+ * `cio_object_id`). Objects use a different id vocabulary than people, so this
+ * is intentionally separate from {@link isIdentifierType}.
+ */
+export const isObjectIdType = (value: unknown) => {
+  return value === 'object_id' || value === 'cio_object_id';
+};
+
+/**
  * Build a URL query string from a map of parameters.
  *
  * `null` and `undefined` values are omitted (so optional params disappear

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -13,6 +13,28 @@ export const isIdentifierType = (value: unknown) => {
 };
 
 /**
+ * Build a URL query string from a map of parameters.
+ *
+ * `null` and `undefined` values are omitted (so optional params disappear
+ * rather than serializing as empty). Keys and values are URL-encoded. Returns
+ * a leading-`?` string (e.g. `?a=1&b=2`) when at least one param is present,
+ * or an empty string when none are.
+ */
+export const buildQueryString = (params: Record<string, string | number | boolean | null | undefined>): string => {
+  const parts: string[] = [];
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value === null || value === undefined) {
+      continue;
+    }
+
+    parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  }
+
+  return parts.length > 0 ? `?${parts.join('&')}` : '';
+};
+
+/**
  * Minimal response shape attached to a {@link CustomerIORequestError}. Replaces
  * the previous `http.IncomingMessage` so the public error type stays portable
  * across runtimes that don't expose Node's stream-based response object.

--- a/test/api.ts
+++ b/test/api.ts
@@ -958,6 +958,9 @@ test('#getObjectAttributes: builds the object path and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getObjectAttributes('', 'acme'), { message: 'objectTypeId is required' });
   t.throws(() => t.context.client.getObjectAttributes(1, ''), { message: 'objectId is required' });
+  t.throws(() => t.context.client.getObjectAttributes(1, 'acme', 'id' as any), {
+    message: 'idType must be one of "object_id" or "cio_object_id"',
+  });
   t.context.client.getObjectAttributes(1, 'acme', 'cio_object_id');
   t.true(get.calledWith(`${API}/objects/1/acme/attributes?id_type=cio_object_id`));
 });
@@ -966,13 +969,16 @@ test('#getObjectRelationships: paginates the object relationships path', (t) => 
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getObjectRelationships('', 'acme'), { message: 'objectTypeId is required' });
   t.throws(() => t.context.client.getObjectRelationships(1, ''), { message: 'objectId is required' });
-  t.context.client.getObjectRelationships(1, 'acme', { start: 'c', limit: 20 });
-  t.true(get.calledWith(`${API}/objects/1/acme/relationships?start=c&limit=20`));
+  t.throws(() => t.context.client.getObjectRelationships(1, 'acme', { idType: 'id' as any }), {
+    message: 'idType must be one of "object_id" or "cio_object_id"',
+  });
+  t.context.client.getObjectRelationships(1, 'acme', { idType: 'object_id', start: 'c', limit: 20 });
+  t.true(get.calledWith(`${API}/objects/1/acme/relationships?id_type=object_id&start=c&limit=20`));
 });
 
 test('#findObjects: posts object_type_id + filter with pagination', (t) => {
   const post = sinon.stub(t.context.client.request, 'post');
-  const filter: Filter = { or: [{ attribute: { field: 'plan', operator: 'eq' as any, value: 'pro' } }] };
+  const filter = { and: [{ object_attribute: { field: 'name', operator: 'eq', value: 'acme', type_id: 1 } }] };
   t.throws(() => t.context.client.findObjects('', filter), { message: 'objectTypeId is required' });
   t.throws(() => (t.context.client.findObjects as any)(1, null), { message: 'filter is required' });
   t.context.client.findObjects(1, filter, { start: 'c' });

--- a/test/api.ts
+++ b/test/api.ts
@@ -863,3 +863,139 @@ test('constructor: cross-copy branded Region passes instanceof check', (t) => {
 
   t.notThrows(() => new APIClient('appKey', { region: fakeRegion as any }));
 });
+
+// --- Batch 1: Customers & objects (CDP-6265) ---
+
+const API = RegionUS.apiUrl;
+
+test('#getCustomerActivities: requires customerId', (t) => {
+  t.throws(() => (t.context.client.getCustomerActivities as any)(''), { message: 'customerId is required' });
+});
+
+test('#getCustomerActivities: validates idType', (t) => {
+  t.throws(() => t.context.client.getCustomerActivities('1', { idType: 'nope' as any }), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+});
+
+test('#getCustomerActivities: no options omits the query string', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.getCustomerActivities('1');
+  t.true(get.calledWith(`${API}/customers/1/activities`));
+});
+
+test('#getCustomerActivities: forwards filters as query params', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.getCustomerActivities('1', {
+    idType: IdentifierType.Email,
+    start: 'abc',
+    limit: 50,
+    type: 'event',
+    name: 'signup',
+  });
+  t.true(get.calledWith(`${API}/customers/1/activities?id_type=email&start=abc&limit=50&type=event&name=signup`));
+});
+
+test('#getCustomerMessages: forwards timestamp filters', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.getCustomerMessages('1', { start_ts: 100, end_ts: 200, limit: 10 });
+  t.true(get.calledWith(`${API}/customers/1/messages?limit=10&start_ts=100&end_ts=200`));
+});
+
+test('#getCustomerMessages: requires customerId and validates idType', (t) => {
+  t.throws(() => (t.context.client.getCustomerMessages as any)(''), { message: 'customerId is required' });
+  t.throws(() => t.context.client.getCustomerMessages('1', { idType: 'nope' as any }), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+});
+
+test('#getCustomerRelationships: paginates and requires customerId', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => (t.context.client.getCustomerRelationships as any)(''), { message: 'customerId is required' });
+  t.context.client.getCustomerRelationships('1', { start: 'cur', limit: 5 });
+  t.true(get.calledWith(`${API}/customers/1/relationships?start=cur&limit=5`));
+});
+
+test('#getCustomerSegments: defaults id_type to id and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => (t.context.client.getCustomerSegments as any)(''), { message: 'customerId is required' });
+  t.throws(() => t.context.client.getCustomerSegments('1', 'nope' as any), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+  t.context.client.getCustomerSegments('1');
+  t.true(get.calledWith(`${API}/customers/1/segments?id_type=id`));
+});
+
+test('#getCustomerSubscriptionPreferences: forwards language and id_type', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => (t.context.client.getCustomerSubscriptionPreferences as any)(''), {
+    message: 'customerId is required',
+  });
+  t.throws(() => t.context.client.getCustomerSubscriptionPreferences('1', { idType: 'nope' as any }), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+  t.context.client.getCustomerSubscriptionPreferences('1', { idType: IdentifierType.CioId, language: 'es-ES' });
+  t.true(get.calledWith(`${API}/customers/1/subscription_preferences?id_type=cio_id&language=es-ES`));
+});
+
+test('#searchCustomers: posts filter with pagination query', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const filter: Filter = { and: [{ segment: { id: 7 } }] };
+  t.throws(() => (t.context.client.searchCustomers as any)(null), { message: 'filter is required' });
+  t.context.client.searchCustomers(filter, { limit: 100 });
+  t.true(post.calledWith(`${API}/customers?limit=100`, { filter }));
+});
+
+test('#getCustomersAttributes: posts a non-empty ids array', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.getCustomersAttributes([]), { message: 'ids is required' });
+  t.throws(() => (t.context.client.getCustomersAttributes as any)('1'), { message: 'ids is required' });
+  t.context.client.getCustomersAttributes(['1', '2']);
+  t.true(post.calledWith(`${API}/customers/attributes`, { ids: ['1', '2'] }));
+});
+
+test('#getObjectAttributes: builds the object path and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getObjectAttributes('', 'acme'), { message: 'objectTypeId is required' });
+  t.throws(() => t.context.client.getObjectAttributes(1, ''), { message: 'objectId is required' });
+  t.context.client.getObjectAttributes(1, 'acme', 'cio_object_id');
+  t.true(get.calledWith(`${API}/objects/1/acme/attributes?id_type=cio_object_id`));
+});
+
+test('#getObjectRelationships: paginates the object relationships path', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getObjectRelationships('', 'acme'), { message: 'objectTypeId is required' });
+  t.throws(() => t.context.client.getObjectRelationships(1, ''), { message: 'objectId is required' });
+  t.context.client.getObjectRelationships(1, 'acme', { start: 'c', limit: 20 });
+  t.true(get.calledWith(`${API}/objects/1/acme/relationships?start=c&limit=20`));
+});
+
+test('#findObjects: posts object_type_id + filter with pagination', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const filter: Filter = { or: [{ attribute: { field: 'plan', operator: 'eq' as any, value: 'pro' } }] };
+  t.throws(() => t.context.client.findObjects('', filter), { message: 'objectTypeId is required' });
+  t.throws(() => (t.context.client.findObjects as any)(1, null), { message: 'filter is required' });
+  t.context.client.findObjects(1, filter, { start: 'c' });
+  t.true(post.calledWith(`${API}/objects?start=c`, { object_type_id: 1, filter }));
+});
+
+test('#listObjectTypes: gets the object_types endpoint', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listObjectTypes();
+  t.true(get.calledWith(`${API}/object_types`));
+});
+
+test('#listActivities: forwards filters and validates idType', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.listActivities({ idType: 'nope' as any }), {
+    message: 'idType must be one of "id", "cio_id", or "email"',
+  });
+  t.context.client.listActivities({ type: 'event', deleted: true, customerId: '1', idType: IdentifierType.Id });
+  t.true(get.calledWith(`${API}/activities?type=event&deleted=true&customer_id=1&id_type=id`));
+});
+
+test('#listActivities: no options omits the query string', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listActivities();
+  t.true(get.calledWith(`${API}/activities`));
+});

--- a/test/integration/live.env.example
+++ b/test/integration/live.env.example
@@ -43,3 +43,6 @@ CIO_TEST_MANUAL_SEGMENT_ID=
 CIO_TEST_FORM_ID=
 # CIO-Delivery-ID for reportMetric + unsubscribe
 CIO_TEST_DELIVERY_ID=
+# Object type id (+ optional object id) for object attribute/relationship/find reads
+CIO_TEST_OBJECT_TYPE_ID=
+CIO_TEST_OBJECT_ID=

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -22,6 +22,8 @@
  *   CIO_TEST_MANUAL_SEGMENT_ID       manual segment id for add/removeCustomersFromSegment
  *   CIO_TEST_FORM_ID                 form id for submitForm
  *   CIO_TEST_DELIVERY_ID             CIO-Delivery-ID for reportMetric + unsubscribe
+ *   CIO_TEST_OBJECT_TYPE_ID          object type id for object attribute/relationship/find reads
+ *   CIO_TEST_OBJECT_ID               object id for object reads (defaults to a throwaway id)
  *
  * Profile lifecycle: one throwaway customer per run, id = `sdk-live-${uuid()}`.
  * Cleanup is best-effort; the dedicated workspace tolerates orphans.
@@ -99,6 +101,71 @@ liveTest('getAttributes returns the seeded profile', async (t) => {
     customer: { attributes: Record<string, string> };
   };
   t.is(result.customer.attributes.first_name, 'SDK');
+});
+
+liveTest('getCustomerActivities lists the profile activities', async (t) => {
+  const result = (await api!.getCustomerActivities(customerId)) as Record<string, unknown>;
+  t.true('activities' in result);
+});
+
+liveTest('getCustomerMessages resolves for the profile', async (t) => {
+  const result = (await api!.getCustomerMessages(customerId)) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+liveTest('getCustomerRelationships resolves for the profile', async (t) => {
+  const result = (await api!.getCustomerRelationships(customerId)) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+liveTest('getCustomerSegments lists the profile segments', async (t) => {
+  const result = (await api!.getCustomerSegments(customerId)) as Record<string, unknown>;
+  t.true('segments' in result);
+});
+
+liveTest('getCustomerSubscriptionPreferences resolves for the profile', async (t) => {
+  const result = (await api!.getCustomerSubscriptionPreferences(customerId)) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+liveTest('getCustomersAttributes returns attributes for the profile', async (t) => {
+  const result = (await api!.getCustomersAttributes([customerId])) as Record<string, unknown>;
+  t.true('customers' in result);
+});
+
+liveTest('searchCustomers resolves against an attribute filter', async (t) => {
+  const filter = {
+    and: [{ attribute: { field: 'plan', operator: 'eq', value: 'sdk-test' } }],
+  } as unknown as Parameters<APIClient['searchCustomers']>[0];
+  const result = (await api!.searchCustomers(filter, { limit: 10 })) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+liveTest('listObjectTypes resolves', async (t) => {
+  const result = (await api!.listObjectTypes()) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+liveTest('listActivities resolves', async (t) => {
+  const result = (await api!.listActivities({ limit: 5 })) as Record<string, unknown>;
+  t.true('activities' in result);
+});
+
+needs('CIO_TEST_OBJECT_TYPE_ID')('object attribute + relationship reads resolve', async (t) => {
+  const typeId = process.env.CIO_TEST_OBJECT_TYPE_ID!;
+  const objectId = process.env.CIO_TEST_OBJECT_ID ?? 'sdk-live-object';
+  await api!.getObjectAttributes(typeId, objectId).catch(() => undefined);
+  await api!.getObjectRelationships(typeId, objectId).catch(() => undefined);
+  t.pass();
+});
+
+needs('CIO_TEST_OBJECT_TYPE_ID')('findObjects resolves for a test object type', async (t) => {
+  const typeId = process.env.CIO_TEST_OBJECT_TYPE_ID!;
+  const filter = {
+    and: [{ attribute: { field: 'name', operator: 'exists' } }],
+  } as unknown as Parameters<APIClient['findObjects']>[1];
+  const result = (await api!.findObjects(typeId, filter, { limit: 5 })) as Record<string, unknown>;
+  t.truthy(result);
 });
 
 liveTest('track records an event on the profile', async (t) => {

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -162,8 +162,8 @@ needs('CIO_TEST_OBJECT_TYPE_ID')('object attribute + relationship reads resolve'
 needs('CIO_TEST_OBJECT_TYPE_ID')('findObjects resolves for a test object type', async (t) => {
   const typeId = process.env.CIO_TEST_OBJECT_TYPE_ID!;
   const filter = {
-    and: [{ attribute: { field: 'name', operator: 'exists' } }],
-  } as unknown as Parameters<APIClient['findObjects']>[1];
+    and: [{ object_attribute: { field: 'name', operator: 'exists', type_id: Number(typeId) } }],
+  };
   const result = (await api!.findObjects(typeId, filter, { limit: 5 })) as Record<string, unknown>;
   t.truthy(result);
 });


### PR DESCRIPTION
Batch 1 of the App API backfill. Adds twelve read/query methods to APIClient:

- `getCustomerActivities` / `getCustomerMessages` / `getCustomerRelationships` / `getCustomerSegments` / `getCustomerSubscriptionPreferences`
- `searchCustomers` (`POST /customers`) and `getCustomersAttributes` (bulk lookup)
- `getObjectAttributes` / `getObjectRelationships` / `findObjects`
- `listObjectTypes` / `listActivities`

Introduces a shared `buildQueryString()` helper in utils for the pagination and filter query params (start/limit/id_type/etc.) that the rest of the App API list endpoints will reuse.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only SDK methods with consistent validation patterns; no changes to sends, auth, or existing method behavior.
> 
> **Overview**
> Expands **`APIClient`** with twelve read/query App API methods (batch 1 of the backfill): person lookups (`getCustomerActivities`, `getCustomerMessages`, `getCustomerRelationships`, `getCustomerSegments`, `getCustomerSubscriptionPreferences`), audience search (`searchCustomers`, `getCustomersAttributes`), object APIs (`getObjectAttributes`, `getObjectRelationships`, `findObjects`, `listObjectTypes`), and workspace-wide `listActivities`.
> 
> Shared **`buildQueryString`** and **`isObjectIdType`** in `utils` centralize optional query params and object id validation; new option types (`PaginationOptions`, etc.) document pagination and filters. **`findObjects`** intentionally types filters as `Record<string, any>` until a dedicated object filter type lands.
> 
> **`docs/app.md`** documents all new methods. Unit tests in **`test/api.ts`** assert URLs, validation, and query serialization; **`test/integration/live.ts`** adds live smoke tests plus optional `CIO_TEST_OBJECT_TYPE_ID` / `CIO_TEST_OBJECT_ID` env vars.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d08aec52e53b95537a2471a10ce8ba72cd6748e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->