### PR TITLE
Prepare v5.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.1.0]
+
+#### Added
+
+- **Track API completeness.** Added the remaining Track API methods to `TrackClient`: `entity` (the single-request counterpart to `batch`), `addCustomersToSegment`, `removeCustomersFromSegment`, `submitForm`, `reportMetric`, `getAccountRegion`, and `unsubscribe`. ([#224](https://github.com/customerio/customerio-node/pull/224))
+- **`verifyRequestSignature`** helper for validating inbound Customer.io reporting webhooks. It recomputes the HMAC-SHA256 signature from your signing secret and compares it in constant time. ([#227](https://github.com/customerio/customerio-node/pull/227))
+- **App API customer & object methods** on `APIClient`: `getCustomerActivities`, `getCustomerMessages`, `getCustomerRelationships`, `getCustomerSegments`, `getCustomerSubscriptionPreferences`, `searchCustomers`, `getCustomersAttributes`, `getObjectAttributes`, `getObjectRelationships`, `findObjects`, `listObjectTypes`, and `listActivities`. ([#228](https://github.com/customerio/customerio-node/pull/228))
+- **App API segment & subscription methods** on `APIClient`: `listSegments`, `createSegment`, `getSegment`, `deleteSegment`, `getSegmentCustomerCount`, `getSegmentMembership`, `getSegmentUsedBy`, `listSubscriptionTopics`, `listSubscriptionChannels`, and `getSubscriptionCenterToken`. ([#229](https://github.com/customerio/customerio-node/pull/229))
+
+#### Fixed
+
+- **`addDevice` no longer drops a `last_used` timestamp of `0`.** A truthy guard previously discarded the Unix epoch; any valid timestamp is now sent. ([#224](https://github.com/customerio/customerio-node/pull/224))
+
+#### Changed
+
+- **API method documentation moved out of the README** into per-client guides under [`docs/`](https://github.com/customerio/customerio-node/tree/main/docs) (Track, App, Pipelines, and Webhooks); the README now links to them. ([#225](https://github.com/customerio/customerio-node/pull/225))
+
+#### Internal
+
+- Publish the generated Typedoc API reference to GitHub Pages via a CI workflow. ([#225](https://github.com/customerio/customerio-node/pull/225))
+- Bump `tar` dev dependency from 7.5.15 to 7.5.16. ([#223](https://github.com/customerio/customerio-node/pull/223))
+
 ## [5.0.1]
 
 #### Fixed

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.0.1';
+export const version = '5.1.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-node",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-node",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
Add the `5.1.0` changelog entries and bump the version from `5.0.1` to `5.1.0`

Assisted with AI 🤖 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and changelog-only changes with no library logic modified in this diff.
> 
> **Overview**
> Release prep for **5.1.0**: version is bumped from `5.0.1` to `5.1.0` in `package.json`, `package-lock.json`, and `lib/version.ts`.
> 
> **CHANGELOG.md** gains a new `## [5.1.0]` section that records work already merged elsewhere—expanded **Track** and **App API** client methods, **`verifyRequestSignature`** for webhooks, the **`addDevice` / `last_used: 0`** fix, docs moved under `docs/`, and internal items (Typedoc on GitHub Pages, `tar` dev bump). This PR does not implement those features; it only publishes the version and release notes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77a3b25cbbc9616c5a673790d1b026f9feb46872. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->