### PR TITLE
Add App API transactional message management methods (CDP-6267)

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -416,6 +416,118 @@ api.getSubscriptionCenterToken("1");
 
 - **customerId**: The person's identifier value (required)
 
+### api.listTransactionalMessages()
+
+List the transactional messages in your workspace.
+
+```javascript
+api.listTransactionalMessages();
+```
+
+### api.getTransactionalMessage(transactionalId)
+
+Get a single transactional message's metadata.
+
+```javascript
+api.getTransactionalMessage(3);
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+
+### api.getTransactionalMessageContents(transactionalId)
+
+List all content variants of a transactional message.
+
+```javascript
+api.getTransactionalMessageContents(3);
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+
+### api.getTransactionalMessageLanguage(transactionalId, language)
+
+Get a single-language translation of a transactional message.
+
+```javascript
+api.getTransactionalMessageLanguage(3, "en-US");
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **language**: The IETF language tag of the translation (required)
+
+### api.updateTransactionalMessageLanguage(transactionalId, language, data)
+
+Update a single-language translation of a transactional message.
+
+```javascript
+api.updateTransactionalMessageLanguage(3, "en-US", { subject: "Welcome!" });
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **language**: The IETF language tag of the translation (required)
+- **data**: The translation fields to update
+
+### api.getTransactionalMessageDeliveries(transactionalId, options)
+
+Get the individual deliveries (sends) of a transactional message.
+
+```javascript
+api.getTransactionalMessageDeliveries(3, { metric: "delivered", limit: 50 });
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **options**: Object (optional) — `start`, `limit`, `metric`, `state`, `start_ts`, `end_ts`, `get_tracked_responses`
+
+### api.getTransactionalMessageMetrics(transactionalId, options)
+
+Get delivery metrics for a transactional message over time.
+
+```javascript
+api.getTransactionalMessageMetrics(3, { period: "days", steps: 14 });
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **options**: Object (optional) — `period` ("hours" / "days" / "weeks" / "months"), `steps`
+
+### api.getTransactionalMessageLinkMetrics(transactionalId, options)
+
+Get link (click) metrics for a transactional message over time.
+
+```javascript
+api.getTransactionalMessageLinkMetrics(3, { period: "weeks", steps: 4, unique: true });
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `unique`
+
+### api.updateTransactionalMessageContent(transactionalId, contentId, data)
+
+Update a transactional message's content variant.
+
+```javascript
+api.updateTransactionalMessageContent(3, 5, { body: "Updated body" });
+```
+
+#### Options
+
+- **transactionalId**: The transactional message's numeric id (required)
+- **contentId**: The content variant's numeric id (required)
+- **data**: The content fields to update
+
 ### api.listExports()
 
 Return a list of your exports. Exports are point-in-time people or campaign metrics.

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -77,6 +77,37 @@ export type SegmentInput = {
   description?: string;
 };
 
+/** Time unit for metric reports. */
+export type MetricsPeriod = 'hours' | 'days' | 'weeks' | 'months';
+
+/** Options for {@link APIClient.getTransactionalMessageMetrics}. */
+export type TransactionalMetricsOptions = {
+  /** The time unit each step represents. */
+  period?: MetricsPeriod;
+  /** The number of periods to report over. */
+  steps?: number;
+};
+
+/** Options for {@link APIClient.getTransactionalMessageLinkMetrics}. */
+export type TransactionalLinkMetricsOptions = TransactionalMetricsOptions & {
+  /** When `true`, count unique clicks per link rather than total clicks. */
+  unique?: boolean;
+};
+
+/** Options for {@link APIClient.getTransactionalMessageDeliveries}. */
+export type TransactionalDeliveriesOptions = PaginationOptions & {
+  /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
+  metric?: string;
+  /** Filter to deliveries in this state. */
+  state?: 'failed' | 'sent' | 'drafted' | 'attempted';
+  /** Only include deliveries after this Unix timestamp (seconds). */
+  start_ts?: number;
+  /** Only include deliveries before this Unix timestamp (seconds). */
+  end_ts?: number;
+  /** When `true`, include tracked responses (reply/click data) on each delivery. */
+  get_tracked_responses?: boolean;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -839,6 +870,183 @@ export class APIClient {
     }
 
     return this.request.get(`${this.apiRoot}/subscription_center/${encodeURIComponent(customerId)}/token`);
+  }
+
+  /**
+   * List the transactional messages in your workspace.
+   *
+   * @returns The parsed JSON response body.
+   */
+  listTransactionalMessages() {
+    return this.request.get(`${this.apiRoot}/transactional`);
+  }
+
+  /**
+   * Get a single transactional message's metadata.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` is empty.
+   */
+  getTransactionalMessage(transactionalId: string | number) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    return this.request.get(`${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}`);
+  }
+
+  /**
+   * List all content variants of a transactional message.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` is empty.
+   */
+  getTransactionalMessageContents(transactionalId: string | number) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    return this.request.get(`${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/contents`);
+  }
+
+  /**
+   * Get a single-language translation of a transactional message.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param language The IETF language tag of the translation.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` or `language` is empty.
+   */
+  getTransactionalMessageLanguage(transactionalId: string | number, language: string) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a transactional message.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param language The IETF language tag of the translation.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` or `language` is empty.
+   */
+  updateTransactionalMessageLanguage(transactionalId: string | number, language: string, data: RequestData = {}) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get the individual deliveries (sends) of a transactional message.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param options Optional filters/pagination. See {@link TransactionalDeliveriesOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` is empty.
+   */
+  getTransactionalMessageDeliveries(transactionalId: string | number, options: TransactionalDeliveriesOptions = {}) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    const query = buildQueryString({
+      start: options.start,
+      limit: options.limit,
+      metric: options.metric,
+      state: options.state,
+      start_ts: options.start_ts,
+      end_ts: options.end_ts,
+      get_tracked_responses: options.get_tracked_responses,
+    });
+
+    return this.request.get(`${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/messages${query}`);
+  }
+
+  /**
+   * Get delivery metrics for a transactional message over time.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param options Optional reporting window. See {@link TransactionalMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` is empty.
+   */
+  getTransactionalMessageMetrics(transactionalId: string | number, options: TransactionalMetricsOptions = {}) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps });
+
+    return this.request.get(`${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/metrics${query}`);
+  }
+
+  /**
+   * Get link (click) metrics for a transactional message over time.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param options Optional reporting window. See {@link TransactionalLinkMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` is empty.
+   */
+  getTransactionalMessageLinkMetrics(transactionalId: string | number, options: TransactionalLinkMetricsOptions = {}) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
+
+    return this.request.get(
+      `${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/metrics/links${query}`,
+    );
+  }
+
+  /**
+   * Update a transactional message's content variant.
+   *
+   * @param transactionalId The transactional message's numeric id.
+   * @param contentId The content variant's numeric id.
+   * @param data The content fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `transactionalId` or `contentId` is empty.
+   */
+  updateTransactionalMessageContent(
+    transactionalId: string | number,
+    contentId: string | number,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(transactionalId)) {
+      throw new MissingParamError('transactionalId');
+    }
+
+    if (isEmpty(contentId)) {
+      throw new MissingParamError('contentId');
+    }
+
+    return this.request.put(
+      `${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/content/${encodeURIComponent(contentId)}`,
+      data,
+    );
   }
 }
 

--- a/test/api.ts
+++ b/test/api.ts
@@ -1082,3 +1082,99 @@ test('#getSubscriptionCenterToken: gets the token endpoint and validates', (t) =
   t.context.client.getSubscriptionCenterToken('1');
   t.true(get.calledWith(`${API}/subscription_center/1/token`));
 });
+
+// --- Batch 3: Transactional message management (CDP-6267) ---
+
+test('#listTransactionalMessages: gets the transactional endpoint', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listTransactionalMessages();
+  t.true(get.calledWith(`${API}/transactional`));
+});
+
+test('#getTransactionalMessage: gets one message and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessage(''), { message: 'transactionalId is required' });
+  t.context.client.getTransactionalMessage(3);
+  t.true(get.calledWith(`${API}/transactional/3`));
+});
+
+test('#getTransactionalMessageContents: gets the contents endpoint and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessageContents(''), { message: 'transactionalId is required' });
+  t.context.client.getTransactionalMessageContents(3);
+  t.true(get.calledWith(`${API}/transactional/3/contents`));
+});
+
+test('#getTransactionalMessageLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessageLanguage('', 'en'), {
+    message: 'transactionalId is required',
+  });
+  t.throws(() => t.context.client.getTransactionalMessageLanguage(3, ''), { message: 'language is required' });
+  t.context.client.getTransactionalMessageLanguage(3, 'en-US');
+  t.true(get.calledWith(`${API}/transactional/3/language/en-US`));
+});
+
+test('#updateTransactionalMessageLanguage: puts the translation body and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateTransactionalMessageLanguage('', 'en', {}), {
+    message: 'transactionalId is required',
+  });
+  t.throws(() => t.context.client.updateTransactionalMessageLanguage(3, '', {}), { message: 'language is required' });
+  t.context.client.updateTransactionalMessageLanguage(3, 'en-US', { subject: 'Hi' });
+  t.true(put.calledWith(`${API}/transactional/3/language/en-US`, { subject: 'Hi' }));
+  t.context.client.updateTransactionalMessageLanguage(3, 'fr');
+  t.true(put.calledWith(`${API}/transactional/3/language/fr`, {}));
+});
+
+test('#getTransactionalMessageDeliveries: forwards filters and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessageDeliveries(''), { message: 'transactionalId is required' });
+  t.context.client.getTransactionalMessageDeliveries(3, {
+    metric: 'delivered',
+    state: 'sent',
+    limit: 50,
+    start_ts: 100,
+    end_ts: 200,
+    get_tracked_responses: true,
+  });
+  t.true(
+    get.calledWith(
+      `${API}/transactional/3/messages?limit=50&metric=delivered&state=sent&start_ts=100&end_ts=200&get_tracked_responses=true`,
+    ),
+  );
+});
+
+test('#getTransactionalMessageDeliveries: omits the query string with no options', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.getTransactionalMessageDeliveries(3);
+  t.true(get.calledWith(`${API}/transactional/3/messages`));
+});
+
+test('#getTransactionalMessageMetrics: forwards period/steps and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessageMetrics(''), { message: 'transactionalId is required' });
+  t.context.client.getTransactionalMessageMetrics(3, { period: 'days', steps: 14 });
+  t.true(get.calledWith(`${API}/transactional/3/metrics?period=days&steps=14`));
+});
+
+test('#getTransactionalMessageLinkMetrics: forwards unique and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getTransactionalMessageLinkMetrics(''), {
+    message: 'transactionalId is required',
+  });
+  t.context.client.getTransactionalMessageLinkMetrics(3, { period: 'weeks', steps: 4, unique: true });
+  t.true(get.calledWith(`${API}/transactional/3/metrics/links?period=weeks&steps=4&unique=true`));
+});
+
+test('#updateTransactionalMessageContent: puts the content body and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateTransactionalMessageContent('', 5, {}), {
+    message: 'transactionalId is required',
+  });
+  t.throws(() => t.context.client.updateTransactionalMessageContent(3, '', {}), { message: 'contentId is required' });
+  t.context.client.updateTransactionalMessageContent(3, 5, { body: 'Updated' });
+  t.true(put.calledWith(`${API}/transactional/3/content/5`, { body: 'Updated' }));
+  t.context.client.updateTransactionalMessageContent(3, 6);
+  t.true(put.calledWith(`${API}/transactional/3/content/6`, {}));
+});

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -207,6 +207,24 @@ liveTest('getSubscriptionCenterToken resolves for the profile', async (t) => {
   t.pass(result ? 'token generated' : 'subscription center not configured; skipped');
 });
 
+liveTest('listTransactionalMessages resolves', async (t) => {
+  const result = (await api!.listTransactionalMessages()) as Record<string, unknown>;
+  t.truthy(result);
+});
+
+// Read-only transactional lookups for a known message id. Update methods
+// (content/language) are covered by unit tests only — they mutate real
+// templates, which we avoid in the dogfood suite.
+needs('CIO_TEST_TRANSACTIONAL_ID')('transactional message reads resolve for a known id', async (t) => {
+  const id = process.env.CIO_TEST_TRANSACTIONAL_ID!;
+  await api!.getTransactionalMessage(id).catch(() => undefined);
+  await api!.getTransactionalMessageContents(id).catch(() => undefined);
+  await api!.getTransactionalMessageDeliveries(id, { limit: 5 }).catch(() => undefined);
+  await api!.getTransactionalMessageMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getTransactionalMessageLinkMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();


### PR DESCRIPTION
This adds more missing methods from the App API. This adds the transactional message management endpoints, complementing the existing `sendEmail`/`sendPush`/etc. send methods.

| Method | Endpoint |
|---|---|
| `listTransactionalMessages` | GET `/transactional` |
| `getTransactionalMessage` | GET `/transactional/{id}` |
| `getTransactionalMessageContents` | GET `/transactional/{id}/contents` |
| `getTransactionalMessageLanguage` | GET `/transactional/{id}/language/{language}` |
| `updateTransactionalMessageLanguage` | PUT `/transactional/{id}/language/{language}` |
| `getTransactionalMessageDeliveries` | GET `/transactional/{id}/messages` |
| `getTransactionalMessageMetrics` | GET `/transactional/{id}/metrics` |
| `getTransactionalMessageLinkMetrics` | GET `/transactional/{id}/metrics/links` |
| `updateTransactionalMessageContent` | PUT `/transactional/{id}/content/{content_id}` 

Assisted by AI 🤖

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PUT methods can change live transactional templates in production workspaces; risk is mitigated by following existing API patterns and limiting live tests to read-only calls.
> 
> **Overview**
> Adds **nine `APIClient` methods** for managing transactional messages via the App API (list/get metadata, contents, per-language translations, delivery listings, delivery and link metrics, and PUT updates for language and content variants). New option types (`MetricsPeriod`, `TransactionalMetricsOptions`, `TransactionalLinkMetricsOptions`, `TransactionalDeliveriesOptions`) type query filters for deliveries and metrics; list/filter endpoints use the existing `buildQueryString` helper and the same `MissingParamError` validation as other client methods.
> 
> **`docs/app.md`** documents each new method. **Unit tests** cover paths, query strings, PUT bodies, and required-param errors. **Live tests** call `listTransactionalMessages` and read-only id-scoped endpoints when `CIO_TEST_TRANSACTIONAL_ID` is set; mutating updates stay unit-tested only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e40a6fed1f5f850332a5235e69f355c55b838bcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->