### PR TITLE
Add App API campaign methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -604,3 +604,201 @@ api.createDeliveriesExport(1, {
 - **options**: Object
 
 You can read more about the available options on the [export deliveries data](https://customer.io/docs/api/#operation/exportDeliveriesData) docs.
+
+### api.listCampaigns()
+
+List the campaigns in your workspace.
+
+```javascript
+api.listCampaigns();
+```
+
+### api.getCampaign(campaignId)
+
+Get a single campaign's metadata.
+
+```javascript
+api.getCampaign(9);
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+
+### api.getCampaignActions(campaignId, options)
+
+List a campaign's actions.
+
+```javascript
+api.getCampaignActions(9, { start: "cursor" });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **options**: Object (optional) — `start` (pagination cursor)
+
+### api.getCampaignAction(campaignId, actionId)
+
+Get a single action of a campaign.
+
+```javascript
+api.getCampaignAction(9, 2);
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+
+### api.updateCampaignAction(campaignId, actionId, data)
+
+Update an action of a campaign.
+
+```javascript
+api.updateCampaignAction(9, 2, { body: "Updated body" });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **data**: The action fields to update
+
+### api.getCampaignActionLanguage(campaignId, actionId, language)
+
+Get a single-language translation of a campaign action.
+
+```javascript
+api.getCampaignActionLanguage(9, 2, "en-US");
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateCampaignActionLanguage(campaignId, actionId, language, data)
+
+Update a single-language translation of a campaign action.
+
+```javascript
+api.updateCampaignActionLanguage(9, 2, "fr", { subject: "Bonjour" });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.getCampaignActionMetrics(campaignId, actionId, version, options)
+
+Get metrics for a single campaign action over time.
+
+```javascript
+api.getCampaignActionMetrics(9, 2, "2", { type: "email", period: "days", steps: 7 });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **version**: Metrics API version — "1" or "2" (required)
+- **options**: Object (optional) — `type`, `res`, `tz`, `start`, `end`, `period`, `steps`
+
+### api.getCampaignActionMetricsLinks(campaignId, actionId, options)
+
+Get link (click) metrics for a single campaign action over time.
+
+```javascript
+api.getCampaignActionMetricsLinks(9, 2, { period: "weeks", steps: 4, type: "email" });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getCampaignMetrics(campaignId, version, options)
+
+Get delivery metrics for a campaign over time.
+
+```javascript
+api.getCampaignMetrics(9, "1", { res: "daily", start: 1719792000, end: 1719878400 });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **version**: Metrics API version — "1" or "2" (required)
+- **options**: Object (optional) — `type`, `res`, `tz`, `start`, `end`, `period`, `steps`
+
+### api.getCampaignMetricsLinks(campaignId, options)
+
+Get link (click) metrics for a campaign over time.
+
+```javascript
+api.getCampaignMetricsLinks(9, { period: "days", steps: 30, unique: true });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `unique`
+
+### api.getCampaignJourneyMetrics(campaignId, options)
+
+Get a campaign's journey metrics (per-step conversion funnel) over a window.
+
+```javascript
+api.getCampaignJourneyMetrics(9, { start: 1719792000, end: 1719878400, res: "daily" });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **options**: Object (required) — `start`, `end`, and `res` are all required
+
+### api.getCampaignMessages(campaignId, options)
+
+Get the individual messages (deliveries) sent by a campaign.
+
+```javascript
+api.getCampaignMessages(9, { type: "email", metric: "delivered", limit: 50 });
+```
+
+#### Options
+
+- **campaignId**: The campaign's numeric id (required)
+- **options**: Object (optional) — `start`, `limit`, `type`, `metric`, `drafts`, `start_ts`, `end_ts`, `get_tracked_responses`
+
+### api.getBroadcastTriggerStatus(broadcastId, triggerId)
+
+Get the status of an API-triggered broadcast run. Pairs with `api.triggerBroadcast`.
+
+```javascript
+api.getBroadcastTriggerStatus(1, 5);
+```
+
+#### Options
+
+- **broadcastId**: The broadcast (campaign) id (required)
+- **triggerId**: The trigger id returned by `triggerBroadcast` (required)
+
+### api.getBroadcastTriggerErrors(broadcastId, triggerId, options)
+
+Get the per-recipient errors for an API-triggered broadcast run.
+
+```javascript
+api.getBroadcastTriggerErrors(1, 5, { limit: 100 });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast (campaign) id (required)
+- **triggerId**: The trigger id (required)
+- **options**: Object (optional) — `start`, `limit`

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -108,6 +108,75 @@ export type TransactionalDeliveriesOptions = PaginationOptions & {
   get_tracked_responses?: boolean;
 };
 
+/** Message channel a metric/message query can be scoped to. */
+export type MetricType = 'email' | 'webhook' | 'twilio' | 'whatsapp' | 'slack' | 'push' | 'in_app';
+
+/** Resolution (bucket size) for time-series metric reports. */
+export type MetricResolution = 'hours' | 'hourly' | 'days' | 'daily' | 'weeks' | 'weekly' | 'months' | 'monthly';
+
+/** Metrics API version for campaign metric reports. */
+export type CampaignMetricsVersion = '1' | '2';
+
+/** Options for channel-scoped metric reports (broadcast metrics, action metrics/links). */
+export type MetricsOptions = {
+  /** The time unit each step represents. */
+  period?: MetricsPeriod;
+  /** The number of periods to report over. */
+  steps?: number;
+  /** Scope the report to a single channel. */
+  type?: MetricType;
+};
+
+/** Options for resource-level link (click) metric reports. */
+export type LinkMetricsOptions = {
+  period?: MetricsPeriod;
+  steps?: number;
+  /** When `true`, count unique clicks per link rather than total clicks. */
+  unique?: boolean;
+};
+
+/** Options for campaign metric reports. Pass the required `version` separately. */
+export type CampaignMetricsOptions = {
+  /** Scope the report to a single channel. */
+  type?: MetricType;
+  /** Resolution (bucket size) of the report. */
+  res?: MetricResolution;
+  /** IANA timezone for bucket boundaries (e.g. `America/New_York`). */
+  tz?: string;
+  /** Inclusive start of the window, as a Unix timestamp (seconds). */
+  start?: number;
+  /** Inclusive end of the window, as a Unix timestamp (seconds). */
+  end?: number;
+  period?: MetricsPeriod;
+  steps?: number;
+};
+
+/** Required options for {@link APIClient.getCampaignJourneyMetrics}. */
+export type JourneyMetricsOptions = {
+  /** Inclusive start of the window, as a Unix timestamp (seconds). */
+  start: number;
+  /** Inclusive end of the window, as a Unix timestamp (seconds). */
+  end: number;
+  /** Resolution (bucket size) of the report. */
+  res: MetricResolution;
+};
+
+/** Options for {@link APIClient.getCampaignMessages}. */
+export type CampaignMessagesOptions = PaginationOptions & {
+  /** Scope to a single channel. */
+  type?: MetricType;
+  /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
+  metric?: string;
+  /** Include drafted (unsent) messages. */
+  drafts?: boolean;
+  /** Only include deliveries after this Unix timestamp (seconds). */
+  start_ts?: number;
+  /** Only include deliveries before this Unix timestamp (seconds). */
+  end_ts?: number;
+  /** When `true`, include tracked responses on each delivery. */
+  get_tracked_responses?: boolean;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -1046,6 +1115,388 @@ export class APIClient {
     return this.request.put(
       `${this.apiRoot}/transactional/${encodeURIComponent(transactionalId)}/content/${encodeURIComponent(contentId)}`,
       data,
+    );
+  }
+
+  /**
+   * Build the base URL for a campaign/broadcast resource. Shared by the
+   * campaign and broadcast methods, which have identical sub-resource paths.
+   */
+  private resourceBase(resource: 'campaigns' | 'broadcasts', id: string | number) {
+    return `${this.apiRoot}/${resource}/${encodeURIComponent(id)}`;
+  }
+
+  /**
+   * List the campaigns in your workspace.
+   *
+   * @returns The parsed JSON response body (`{ campaigns: [...] }`).
+   */
+  listCampaigns() {
+    return this.request.get(`${this.apiRoot}/campaigns`);
+  }
+
+  /**
+   * Get a single campaign's metadata.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` is empty.
+   */
+  getCampaign(campaignId: string | number) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    return this.request.get(this.resourceBase('campaigns', campaignId));
+  }
+
+  /**
+   * List a campaign's actions.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param options Optional pagination cursor (`start`).
+   * @returns The parsed JSON response body (`{ actions: [...], next }`).
+   * @throws {MissingParamError} If `campaignId` is empty.
+   */
+  getCampaignActions(campaignId: string | number, options: { start?: string } = {}) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    const query = buildQueryString({ start: options.start });
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/actions${query}`);
+  }
+
+  /**
+   * Get a single action of a campaign.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` or `actionId` is empty.
+   */
+  getCampaignAction(campaignId: string | number, actionId: string | number) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}`);
+  }
+
+  /**
+   * Update an action of a campaign (e.g. its message content).
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @param data The action fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` or `actionId` is empty.
+   */
+  updateCampaignAction(campaignId: string | number, actionId: string | number, data: RequestData = {}) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get a single-language translation of a campaign action.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId`, `actionId`, or `language` is empty.
+   */
+  getCampaignActionLanguage(campaignId: string | number, actionId: string | number, language: string) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a campaign action.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId`, `actionId`, or `language` is empty.
+   */
+  updateCampaignActionLanguage(
+    campaignId: string | number,
+    actionId: string | number,
+    language: string,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get metrics for a single campaign action over time.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @param version The metrics API version (`"1"` or `"2"`) — required by the API.
+   * @param options Optional reporting window/filters. See {@link CampaignMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId`, `actionId`, or `version` is empty.
+   */
+  getCampaignActionMetrics(
+    campaignId: string | number,
+    actionId: string | number,
+    version: CampaignMetricsVersion,
+    options: CampaignMetricsOptions = {},
+  ) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    if (isEmpty(version)) {
+      throw new MissingParamError('version');
+    }
+
+    const query = buildQueryString({
+      version,
+      type: options.type,
+      res: options.res,
+      tz: options.tz,
+      start: options.start,
+      end: options.end,
+      period: options.period,
+      steps: options.steps,
+    });
+
+    return this.request.get(
+      `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}/metrics${query}`,
+    );
+  }
+
+  /**
+   * Get link (click) metrics for a single campaign action over time.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param actionId The action's numeric id.
+   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` or `actionId` is empty.
+   */
+  getCampaignActionMetricsLinks(campaignId: string | number, actionId: string | number, options: MetricsOptions = {}) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(
+      `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}/metrics/links${query}`,
+    );
+  }
+
+  /**
+   * Get delivery metrics for a campaign over time.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param version The metrics API version (`"1"` or `"2"`) — required by the API.
+   * @param options Optional reporting window/filters. See {@link CampaignMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` or `version` is empty.
+   */
+  getCampaignMetrics(
+    campaignId: string | number,
+    version: CampaignMetricsVersion,
+    options: CampaignMetricsOptions = {},
+  ) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (isEmpty(version)) {
+      throw new MissingParamError('version');
+    }
+
+    const query = buildQueryString({
+      version,
+      type: options.type,
+      res: options.res,
+      tz: options.tz,
+      start: options.start,
+      end: options.end,
+      period: options.period,
+      steps: options.steps,
+    });
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/metrics${query}`);
+  }
+
+  /**
+   * Get link (click) metrics for a campaign over time.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` is empty.
+   */
+  getCampaignMetricsLinks(campaignId: string | number, options: LinkMetricsOptions = {}) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/metrics/links${query}`);
+  }
+
+  /**
+   * Get a campaign's journey metrics (per-step conversion funnel) over a window.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param options Required window and resolution. See {@link JourneyMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId`, `options.start`, `options.end`, or `options.res` is empty.
+   */
+  getCampaignJourneyMetrics(campaignId: string | number, options: JourneyMetricsOptions) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    if (options == null || isEmpty(options.start)) {
+      throw new MissingParamError('options.start');
+    }
+
+    if (isEmpty(options.end)) {
+      throw new MissingParamError('options.end');
+    }
+
+    if (isEmpty(options.res)) {
+      throw new MissingParamError('options.res');
+    }
+
+    const query = buildQueryString({ start: options.start, end: options.end, res: options.res });
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/journey_metrics${query}`);
+  }
+
+  /**
+   * Get the individual messages (deliveries) sent by a campaign.
+   *
+   * @param campaignId The campaign's numeric id.
+   * @param options Optional filters/pagination. See {@link CampaignMessagesOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `campaignId` is empty.
+   */
+  getCampaignMessages(campaignId: string | number, options: CampaignMessagesOptions = {}) {
+    if (isEmpty(campaignId)) {
+      throw new MissingParamError('campaignId');
+    }
+
+    const query = buildQueryString({
+      start: options.start,
+      limit: options.limit,
+      type: options.type,
+      metric: options.metric,
+      drafts: options.drafts,
+      start_ts: options.start_ts,
+      end_ts: options.end_ts,
+      get_tracked_responses: options.get_tracked_responses,
+    });
+
+    return this.request.get(`${this.resourceBase('campaigns', campaignId)}/messages${query}`);
+  }
+
+  /**
+   * Get the status of an API-triggered broadcast run. Pairs with {@link APIClient.triggerBroadcast}.
+   *
+   * @param broadcastId The broadcast (campaign) id.
+   * @param triggerId The trigger id returned by `triggerBroadcast`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `triggerId` is empty.
+   */
+  getBroadcastTriggerStatus(broadcastId: string | number, triggerId: string | number) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(triggerId)) {
+      throw new MissingParamError('triggerId');
+    }
+
+    return this.request.get(
+      `${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers/${encodeURIComponent(triggerId)}`,
+    );
+  }
+
+  /**
+   * Get the per-recipient errors for an API-triggered broadcast run.
+   *
+   * @param broadcastId The broadcast (campaign) id.
+   * @param triggerId The trigger id returned by `triggerBroadcast`.
+   * @param options Optional pagination. See {@link PaginationOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `triggerId` is empty.
+   */
+  getBroadcastTriggerErrors(broadcastId: string | number, triggerId: string | number, options: PaginationOptions = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(triggerId)) {
+      throw new MissingParamError('triggerId');
+    }
+
+    const query = buildQueryString({ start: options.start, limit: options.limit });
+
+    return this.request.get(
+      `${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers/${encodeURIComponent(triggerId)}/errors${query}`,
     );
   }
 }

--- a/test/api.ts
+++ b/test/api.ts
@@ -1178,3 +1178,143 @@ test('#updateTransactionalMessageContent: puts the content body and validates', 
   t.context.client.updateTransactionalMessageContent(3, 6);
   t.true(put.calledWith(`${API}/transactional/3/content/6`, {}));
 });
+
+// --- Batch 4: Campaigns (CDP-6268) ---
+
+test('#listCampaigns: gets the campaigns endpoint', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listCampaigns();
+  t.true(get.calledWith(`${API}/campaigns`));
+});
+
+test('#getCampaign: gets one campaign and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaign(''), { message: 'campaignId is required' });
+  t.context.client.getCampaign(9);
+  t.true(get.calledWith(`${API}/campaigns/9`));
+});
+
+test('#getCampaignActions: lists actions with optional start', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignActions(''), { message: 'campaignId is required' });
+  t.context.client.getCampaignActions(9);
+  t.true(get.calledWith(`${API}/campaigns/9/actions`));
+  t.context.client.getCampaignActions(9, { start: 'cur' });
+  t.true(get.calledWith(`${API}/campaigns/9/actions?start=cur`));
+});
+
+test('#getCampaignAction: gets one action and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignAction('', 2), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignAction(9, ''), { message: 'actionId is required' });
+  t.context.client.getCampaignAction(9, 2);
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2`));
+});
+
+test('#updateCampaignAction: puts the body and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateCampaignAction('', 2, {}), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.updateCampaignAction(9, '', {}), { message: 'actionId is required' });
+  t.context.client.updateCampaignAction(9, 2, { body: 'x' });
+  t.true(put.calledWith(`${API}/campaigns/9/actions/2`, { body: 'x' }));
+  t.context.client.updateCampaignAction(9, 2);
+  t.true(put.calledWith(`${API}/campaigns/9/actions/2`, {}));
+});
+
+test('#getCampaignActionLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignActionLanguage('', 2, 'en'), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignActionLanguage(9, '', 'en'), { message: 'actionId is required' });
+  t.throws(() => t.context.client.getCampaignActionLanguage(9, 2, ''), { message: 'language is required' });
+  t.context.client.getCampaignActionLanguage(9, 2, 'en-US');
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2/language/en-US`));
+});
+
+test('#updateCampaignActionLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateCampaignActionLanguage('', 2, 'en', {}), {
+    message: 'campaignId is required',
+  });
+  t.throws(() => t.context.client.updateCampaignActionLanguage(9, '', 'en', {}), { message: 'actionId is required' });
+  t.throws(() => t.context.client.updateCampaignActionLanguage(9, 2, '', {}), { message: 'language is required' });
+  t.context.client.updateCampaignActionLanguage(9, 2, 'fr', { subject: 'Bonjour' });
+  t.true(put.calledWith(`${API}/campaigns/9/actions/2/language/fr`, { subject: 'Bonjour' }));
+  t.context.client.updateCampaignActionLanguage(9, 2, 'fr');
+  t.true(put.calledWith(`${API}/campaigns/9/actions/2/language/fr`, {}));
+});
+
+test('#getCampaignActionMetrics: forwards version + options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignActionMetrics('', 2, '1'), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignActionMetrics(9, '', '1'), { message: 'actionId is required' });
+  t.throws(() => t.context.client.getCampaignActionMetrics(9, 2, '' as any), { message: 'version is required' });
+  t.context.client.getCampaignActionMetrics(9, 2, '2', { type: 'email', period: 'days', steps: 7 });
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics?version=2&type=email&period=days&steps=7`));
+});
+
+test('#getCampaignActionMetricsLinks: forwards type and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignActionMetricsLinks('', 2), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignActionMetricsLinks(9, ''), { message: 'actionId is required' });
+  t.context.client.getCampaignActionMetricsLinks(9, 2, { period: 'weeks', steps: 4, type: 'push' });
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics/links?period=weeks&steps=4&type=push`));
+});
+
+test('#getCampaignMetrics: forwards version + options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignMetrics('', '1'), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignMetrics(9, '' as any), { message: 'version is required' });
+  t.context.client.getCampaignMetrics(9, '1', { res: 'daily', tz: 'America/New_York', start: 100, end: 200 });
+  t.true(get.calledWith(`${API}/campaigns/9/metrics?version=1&res=daily&tz=America%2FNew_York&start=100&end=200`));
+});
+
+test('#getCampaignMetricsLinks: forwards unique and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignMetricsLinks(''), { message: 'campaignId is required' });
+  t.context.client.getCampaignMetricsLinks(9, { period: 'days', steps: 30, unique: true });
+  t.true(get.calledWith(`${API}/campaigns/9/metrics/links?period=days&steps=30&unique=true`));
+});
+
+test('#getCampaignJourneyMetrics: requires window + resolution', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignJourneyMetrics('', { start: 1, end: 2, res: 'days' }), {
+    message: 'campaignId is required',
+  });
+  t.throws(() => (t.context.client.getCampaignJourneyMetrics as any)(9, null), {
+    message: 'options.start is required',
+  });
+  t.throws(() => (t.context.client.getCampaignJourneyMetrics as any)(9, { end: 2, res: 'days' }), {
+    message: 'options.start is required',
+  });
+  t.throws(() => (t.context.client.getCampaignJourneyMetrics as any)(9, { start: 1, res: 'days' }), {
+    message: 'options.end is required',
+  });
+  t.throws(() => (t.context.client.getCampaignJourneyMetrics as any)(9, { start: 1, end: 2 }), {
+    message: 'options.res is required',
+  });
+  t.context.client.getCampaignJourneyMetrics(9, { start: 100, end: 200, res: 'daily' });
+  t.true(get.calledWith(`${API}/campaigns/9/journey_metrics?start=100&end=200&res=daily`));
+});
+
+test('#getCampaignMessages: forwards filters and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getCampaignMessages(''), { message: 'campaignId is required' });
+  t.context.client.getCampaignMessages(9, { type: 'email', metric: 'delivered', drafts: true, limit: 50 });
+  t.true(get.calledWith(`${API}/campaigns/9/messages?limit=50&type=email&metric=delivered&drafts=true`));
+});
+
+test('#getBroadcastTriggerStatus: gets the trigger status and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastTriggerStatus('', 5), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastTriggerStatus(1, ''), { message: 'triggerId is required' });
+  t.context.client.getBroadcastTriggerStatus(1, 5);
+  t.true(get.calledWith(`${API}/campaigns/1/triggers/5`));
+});
+
+test('#getBroadcastTriggerErrors: paginates and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastTriggerErrors('', 5), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastTriggerErrors(1, ''), { message: 'triggerId is required' });
+  t.context.client.getBroadcastTriggerErrors(1, 5, { start: 'c', limit: 10 });
+  t.true(get.calledWith(`${API}/campaigns/1/triggers/5/errors?start=c&limit=10`));
+});

--- a/test/integration/live.env.example
+++ b/test/integration/live.env.example
@@ -37,6 +37,10 @@ CIO_TEST_INAPP_TRANSACTIONAL_ID=
 CIO_TEST_INBOX_TRANSACTIONAL_ID=
 CIO_TEST_BROADCAST_ID=
 CIO_TEST_NEWSLETTER_ID=
+# Campaign id for campaign read methods
+CIO_TEST_CAMPAIGN_ID=
+# Trigger id (with CIO_TEST_BROADCAST_ID) for broadcast trigger status/errors
+CIO_TEST_TRIGGER_ID=
 # Manual segment id for add/removeCustomersFromSegment
 CIO_TEST_MANUAL_SEGMENT_ID=
 # Form id for submitForm

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -24,6 +24,8 @@
  *   CIO_TEST_DELIVERY_ID             CIO-Delivery-ID for reportMetric + unsubscribe
  *   CIO_TEST_OBJECT_TYPE_ID          object type id for object attribute/relationship/find reads
  *   CIO_TEST_OBJECT_ID               object id for object reads (defaults to a throwaway id)
+ *   CIO_TEST_CAMPAIGN_ID             campaign id for campaign read methods
+ *   CIO_TEST_TRIGGER_ID              trigger id (with CIO_TEST_BROADCAST_ID) for trigger status/errors
  *
  * Profile lifecycle: one throwaway customer per run, id = `sdk-live-${uuid()}`.
  * Cleanup is best-effort; the dedicated workspace tolerates orphans.
@@ -222,6 +224,34 @@ needs('CIO_TEST_TRANSACTIONAL_ID')('transactional message reads resolve for a kn
   await api!.getTransactionalMessageDeliveries(id, { limit: 5 }).catch(() => undefined);
   await api!.getTransactionalMessageMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
   await api!.getTransactionalMessageLinkMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  t.pass();
+});
+
+liveTest('listCampaigns resolves', async (t) => {
+  const result = (await api!.listCampaigns()) as Record<string, unknown>;
+  t.true('campaigns' in result);
+});
+
+// Read-only campaign lookups for a known campaign id. Action update methods
+// are covered by unit tests only (they mutate live campaigns).
+needs('CIO_TEST_CAMPAIGN_ID')('campaign reads resolve for a known id', async (t) => {
+  const id = process.env.CIO_TEST_CAMPAIGN_ID!;
+  const end = Math.floor(Date.now() / 1000);
+  const start = end - 7 * 24 * 60 * 60;
+  await api!.getCampaign(id).catch(() => undefined);
+  await api!.getCampaignActions(id).catch(() => undefined);
+  await api!.getCampaignMetrics(id, '1', { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getCampaignMetricsLinks(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getCampaignJourneyMetrics(id, { start, end, res: 'days' }).catch(() => undefined);
+  await api!.getCampaignMessages(id, { limit: 5 }).catch(() => undefined);
+  t.pass();
+});
+
+needs('CIO_TEST_TRIGGER_ID')('broadcast trigger status + errors resolve', async (t) => {
+  const broadcastId = process.env.CIO_TEST_BROADCAST_ID ?? '';
+  const triggerId = process.env.CIO_TEST_TRIGGER_ID!;
+  await api!.getBroadcastTriggerStatus(broadcastId, triggerId).catch(() => undefined);
+  await api!.getBroadcastTriggerErrors(broadcastId, triggerId, { limit: 5 }).catch(() => undefined);
   t.pass();
 });
 


### PR DESCRIPTION
This is the next set of App API methods, which adds the campaign endpoints to `APIClient`.

## New methods (15)

`listCampaigns`, `getCampaign`, `getCampaignActions`, `getCampaignAction`, `updateCampaignAction`, `getCampaignActionLanguage`, `updateCampaignActionLanguage`, `getCampaignActionMetrics`, `getCampaignActionMetricsLinks`, `getCampaignMetrics`, `getCampaignMetricsLinks`, `getCampaignJourneyMetrics`, `getCampaignMessages`, `getBroadcastTriggerStatus`, `getBroadcastTriggerErrors`.

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds PUT helpers that can change live campaign content if misused; otherwise additive HTTP wrappers with validation consistent with existing client patterns.
> 
> **Overview**
> Adds **15 `APIClient` methods** for Customer.io **campaign** resources and **API-triggered broadcast** follow-up, plus typed options for metrics and message listing.
> 
> **Campaign coverage** includes listing campaigns, reading/updating actions and per-language translations, time-series and link metrics (with required metrics `version` where the API demands it), journey funnel metrics, and paginated campaign deliveries. A private **`resourceBase`** helper builds shared `/campaigns/{id}` paths. **`getBroadcastTriggerStatus`** and **`getBroadcastTriggerErrors`** complement existing **`triggerBroadcast`**.
> 
> **Docs** in `docs/app.md` document each method with examples and option lists. **Unit tests** assert URLs, query strings, validation, and PUT bodies. **Live tests** add `listCampaigns` unconditionally and gate deeper campaign/trigger reads on **`CIO_TEST_CAMPAIGN_ID`** / **`CIO_TEST_TRIGGER_ID`**; mutating action updates stay unit-tested only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b63a472d07742c9184f26fcf9b980559c8ac1cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->