### PR TITLE
Add App API broadcast methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -802,3 +802,170 @@ api.getBroadcastTriggerErrors(1, 5, { limit: 100 });
 - **broadcastId**: The broadcast (campaign) id (required)
 - **triggerId**: The trigger id (required)
 - **options**: Object (optional) — `start`, `limit`
+
+### api.listBroadcasts()
+
+List the broadcasts in your workspace.
+
+```javascript
+api.listBroadcasts();
+```
+
+### api.getBroadcast(broadcastId)
+
+Get a single broadcast's metadata.
+
+```javascript
+api.getBroadcast(4);
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+
+### api.getBroadcastActions(broadcastId)
+
+List a broadcast's actions.
+
+```javascript
+api.getBroadcastActions(4);
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+
+### api.getBroadcastAction(broadcastId, actionId)
+
+Get a single action of a broadcast.
+
+```javascript
+api.getBroadcastAction(4, 2);
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+
+### api.updateBroadcastAction(broadcastId, actionId, data)
+
+Update an action of a broadcast.
+
+```javascript
+api.updateBroadcastAction(4, 2, { body: "Updated body" });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **data**: The action fields to update
+
+### api.getBroadcastActionLanguage(broadcastId, actionId, language)
+
+Get a single-language translation of a broadcast action.
+
+```javascript
+api.getBroadcastActionLanguage(4, 2, "en-US");
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateBroadcastActionLanguage(broadcastId, actionId, language, data)
+
+Update a single-language translation of a broadcast action.
+
+```javascript
+api.updateBroadcastActionLanguage(4, 2, "fr", { subject: "Bonjour" });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.getBroadcastActionMetrics(broadcastId, actionId, options)
+
+Get metrics for a single broadcast action over time.
+
+```javascript
+api.getBroadcastActionMetrics(4, 2, { period: "days", steps: 7, type: "email" });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getBroadcastActionMetricsLinks(broadcastId, actionId, options)
+
+Get link (click) metrics for a single broadcast action over time.
+
+```javascript
+api.getBroadcastActionMetricsLinks(4, 2, { period: "weeks", steps: 4, type: "email" });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **actionId**: The action's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getBroadcastMetrics(broadcastId, options)
+
+Get delivery metrics for a broadcast over time.
+
+```javascript
+api.getBroadcastMetrics(4, { period: "days", steps: 30, type: "email" });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getBroadcastMetricsLinks(broadcastId, options)
+
+Get link (click) metrics for a broadcast over time.
+
+```javascript
+api.getBroadcastMetricsLinks(4, { period: "days", steps: 30, unique: true });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `unique`
+
+### api.getBroadcastMessages(broadcastId, options)
+
+Get the individual messages (deliveries) sent by a broadcast.
+
+```javascript
+api.getBroadcastMessages(4, { metric: "delivered", state: "sent", limit: 50 });
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)
+- **options**: Object (optional) — `start`, `limit`, `metric`, `state`, `type`, `start_ts`, `end_ts`, `get_tracked_responses`
+
+### api.getBroadcastTriggers(broadcastId)
+
+List the API triggers fired for a broadcast.
+
+```javascript
+api.getBroadcastTriggers(4);
+```
+
+#### Options
+
+- **broadcastId**: The broadcast's numeric id (required)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -177,6 +177,22 @@ export type CampaignMessagesOptions = PaginationOptions & {
   get_tracked_responses?: boolean;
 };
 
+/** Options for {@link APIClient.getBroadcastMessages}. */
+export type BroadcastMessagesOptions = PaginationOptions & {
+  /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
+  metric?: string;
+  /** Filter to deliveries in this state. */
+  state?: 'failed' | 'sent' | 'drafted' | 'attempted';
+  /** Scope to a single channel. */
+  type?: MetricType;
+  /** Only include deliveries after this Unix timestamp (seconds). */
+  start_ts?: number;
+  /** Only include deliveries before this Unix timestamp (seconds). */
+  end_ts?: number;
+  /** When `true`, include tracked responses on each delivery. */
+  get_tracked_responses?: boolean;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -1498,6 +1514,282 @@ export class APIClient {
     return this.request.get(
       `${this.apiRoot}/campaigns/${encodeURIComponent(broadcastId)}/triggers/${encodeURIComponent(triggerId)}/errors${query}`,
     );
+  }
+
+  /**
+   * List the broadcasts in your workspace.
+   *
+   * @returns The parsed JSON response body (`{ broadcasts: [...] }`).
+   */
+  listBroadcasts() {
+    return this.request.get(`${this.apiRoot}/broadcasts`);
+  }
+
+  /**
+   * Get a single broadcast's metadata.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcast(broadcastId: string | number) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    return this.request.get(this.resourceBase('broadcasts', broadcastId));
+  }
+
+  /**
+   * List a broadcast's actions.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @returns The parsed JSON response body (`{ actions: [...] }`).
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcastActions(broadcastId: string | number) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/actions`);
+  }
+
+  /**
+   * Get a single action of a broadcast.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
+   */
+  getBroadcastAction(broadcastId: string | number, actionId: string | number) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}`);
+  }
+
+  /**
+   * Update an action of a broadcast (e.g. its message content).
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @param data The action fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
+   */
+  updateBroadcastAction(broadcastId: string | number, actionId: string | number, data: RequestData = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get a single-language translation of a broadcast action.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId`, `actionId`, or `language` is empty.
+   */
+  getBroadcastActionLanguage(broadcastId: string | number, actionId: string | number, language: string) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a broadcast action.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId`, `actionId`, or `language` is empty.
+   */
+  updateBroadcastActionLanguage(
+    broadcastId: string | number,
+    actionId: string | number,
+    language: string,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get metrics for a single broadcast action over time.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
+   */
+  getBroadcastActionMetrics(broadcastId: string | number, actionId: string | number, options: MetricsOptions = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(
+      `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/metrics${query}`,
+    );
+  }
+
+  /**
+   * Get link (click) metrics for a single broadcast action over time.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param actionId The action's numeric id.
+   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
+   */
+  getBroadcastActionMetricsLinks(
+    broadcastId: string | number,
+    actionId: string | number,
+    options: MetricsOptions = {},
+  ) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    if (isEmpty(actionId)) {
+      throw new MissingParamError('actionId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(
+      `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/metrics/links${query}`,
+    );
+  }
+
+  /**
+   * Get delivery metrics for a broadcast over time.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcastMetrics(broadcastId: string | number, options: MetricsOptions = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/metrics${query}`);
+  }
+
+  /**
+   * Get link (click) metrics for a broadcast over time.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcastMetricsLinks(broadcastId: string | number, options: LinkMetricsOptions = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/metrics/links${query}`);
+  }
+
+  /**
+   * Get the individual messages (deliveries) sent by a broadcast.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @param options Optional filters/pagination. See {@link BroadcastMessagesOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcastMessages(broadcastId: string | number, options: BroadcastMessagesOptions = {}) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    const query = buildQueryString({
+      start: options.start,
+      limit: options.limit,
+      metric: options.metric,
+      state: options.state,
+      type: options.type,
+      start_ts: options.start_ts,
+      end_ts: options.end_ts,
+      get_tracked_responses: options.get_tracked_responses,
+    });
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/messages${query}`);
+  }
+
+  /**
+   * List the API triggers fired for a broadcast.
+   *
+   * @param broadcastId The broadcast's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `broadcastId` is empty.
+   */
+  getBroadcastTriggers(broadcastId: string | number) {
+    if (isEmpty(broadcastId)) {
+      throw new MissingParamError('broadcastId');
+    }
+
+    return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/triggers`);
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -99,7 +99,7 @@ export type TransactionalDeliveriesOptions = PaginationOptions & {
   /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
   metric?: string;
   /** Filter to deliveries in this state. */
-  state?: 'failed' | 'sent' | 'drafted' | 'attempted';
+  state?: DeliveryState;
   /** Only include deliveries after this Unix timestamp (seconds). */
   start_ts?: number;
   /** Only include deliveries before this Unix timestamp (seconds). */
@@ -113,6 +113,9 @@ export type MetricType = 'email' | 'webhook' | 'twilio' | 'whatsapp' | 'slack' |
 
 /** Resolution (bucket size) for time-series metric reports. */
 export type MetricResolution = 'hours' | 'hourly' | 'days' | 'daily' | 'weeks' | 'weekly' | 'months' | 'monthly';
+
+/** Delivery state a message/delivery listing can be filtered by. */
+export type DeliveryState = 'failed' | 'sent' | 'drafted' | 'attempted';
 
 /** Metrics API version for campaign metric reports. */
 export type CampaignMetricsVersion = '1' | '2';
@@ -182,7 +185,7 @@ export type BroadcastMessagesOptions = PaginationOptions & {
   /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
   metric?: string;
   /** Filter to deliveries in this state. */
-  state?: 'failed' | 'sent' | 'drafted' | 'attempted';
+  state?: DeliveryState;
   /** Scope to a single channel. */
   type?: MetricType;
   /** Only include deliveries after this Unix timestamp (seconds). */

--- a/test/api.ts
+++ b/test/api.ts
@@ -1318,3 +1318,109 @@ test('#getBroadcastTriggerErrors: paginates and validates', (t) => {
   t.context.client.getBroadcastTriggerErrors(1, 5, { start: 'c', limit: 10 });
   t.true(get.calledWith(`${API}/campaigns/1/triggers/5/errors?start=c&limit=10`));
 });
+
+// --- Batch 5: Broadcasts (CDP-6269) ---
+
+test('#listBroadcasts: gets the broadcasts endpoint', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listBroadcasts();
+  t.true(get.calledWith(`${API}/broadcasts`));
+});
+
+test('#getBroadcast: gets one broadcast and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcast(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcast(4);
+  t.true(get.calledWith(`${API}/broadcasts/4`));
+});
+
+test('#getBroadcastActions: lists actions and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastActions(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcastActions(4);
+  t.true(get.calledWith(`${API}/broadcasts/4/actions`));
+});
+
+test('#getBroadcastAction: gets one action and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastAction('', 2), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastAction(4, ''), { message: 'actionId is required' });
+  t.context.client.getBroadcastAction(4, 2);
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2`));
+});
+
+test('#updateBroadcastAction: puts the body and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateBroadcastAction('', 2, {}), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.updateBroadcastAction(4, '', {}), { message: 'actionId is required' });
+  t.context.client.updateBroadcastAction(4, 2, { body: 'x' });
+  t.true(put.calledWith(`${API}/broadcasts/4/actions/2`, { body: 'x' }));
+  t.context.client.updateBroadcastAction(4, 2);
+  t.true(put.calledWith(`${API}/broadcasts/4/actions/2`, {}));
+});
+
+test('#getBroadcastActionLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastActionLanguage('', 2, 'en'), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastActionLanguage(4, '', 'en'), { message: 'actionId is required' });
+  t.throws(() => t.context.client.getBroadcastActionLanguage(4, 2, ''), { message: 'language is required' });
+  t.context.client.getBroadcastActionLanguage(4, 2, 'en-US');
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/language/en-US`));
+});
+
+test('#updateBroadcastActionLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateBroadcastActionLanguage('', 2, 'en', {}), {
+    message: 'broadcastId is required',
+  });
+  t.throws(() => t.context.client.updateBroadcastActionLanguage(4, '', 'en', {}), { message: 'actionId is required' });
+  t.throws(() => t.context.client.updateBroadcastActionLanguage(4, 2, '', {}), { message: 'language is required' });
+  t.context.client.updateBroadcastActionLanguage(4, 2, 'fr', { subject: 'Bonjour' });
+  t.true(put.calledWith(`${API}/broadcasts/4/actions/2/language/fr`, { subject: 'Bonjour' }));
+  t.context.client.updateBroadcastActionLanguage(4, 2, 'fr');
+  t.true(put.calledWith(`${API}/broadcasts/4/actions/2/language/fr`, {}));
+});
+
+test('#getBroadcastActionMetrics: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastActionMetrics('', 2), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastActionMetrics(4, ''), { message: 'actionId is required' });
+  t.context.client.getBroadcastActionMetrics(4, 2, { period: 'days', steps: 7, type: 'email' });
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics?period=days&steps=7&type=email`));
+});
+
+test('#getBroadcastActionMetricsLinks: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastActionMetricsLinks('', 2), { message: 'broadcastId is required' });
+  t.throws(() => t.context.client.getBroadcastActionMetricsLinks(4, ''), { message: 'actionId is required' });
+  t.context.client.getBroadcastActionMetricsLinks(4, 2, { period: 'weeks', steps: 4, type: 'push' });
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics/links?period=weeks&steps=4&type=push`));
+});
+
+test('#getBroadcastMetrics: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastMetrics(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcastMetrics(4, { period: 'days', steps: 30, type: 'email' });
+  t.true(get.calledWith(`${API}/broadcasts/4/metrics?period=days&steps=30&type=email`));
+});
+
+test('#getBroadcastMetricsLinks: forwards unique and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastMetricsLinks(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcastMetricsLinks(4, { period: 'days', steps: 30, unique: true });
+  t.true(get.calledWith(`${API}/broadcasts/4/metrics/links?period=days&steps=30&unique=true`));
+});
+
+test('#getBroadcastMessages: forwards filters and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastMessages(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcastMessages(4, { metric: 'delivered', state: 'sent', type: 'email', limit: 50 });
+  t.true(get.calledWith(`${API}/broadcasts/4/messages?limit=50&metric=delivered&state=sent&type=email`));
+});
+
+test('#getBroadcastTriggers: gets the triggers endpoint and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getBroadcastTriggers(''), { message: 'broadcastId is required' });
+  t.context.client.getBroadcastTriggers(4);
+  t.true(get.calledWith(`${API}/broadcasts/4/triggers`));
+});

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -255,6 +255,24 @@ needs('CIO_TEST_TRIGGER_ID')('broadcast trigger status + errors resolve', async 
   t.pass();
 });
 
+liveTest('listBroadcasts resolves', async (t) => {
+  const result = (await api!.listBroadcasts()) as Record<string, unknown>;
+  t.true('broadcasts' in result);
+});
+
+// Read-only broadcast lookups for a known broadcast id. Action update methods
+// are covered by unit tests only (they mutate live broadcasts).
+needs('CIO_TEST_BROADCAST_ID')('broadcast reads resolve for a known id', async (t) => {
+  const id = process.env.CIO_TEST_BROADCAST_ID!;
+  await api!.getBroadcast(id).catch(() => undefined);
+  await api!.getBroadcastActions(id).catch(() => undefined);
+  await api!.getBroadcastMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getBroadcastMetricsLinks(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getBroadcastMessages(id, { limit: 5 }).catch(() => undefined);
+  await api!.getBroadcastTriggers(id).catch(() => undefined);
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();


### PR DESCRIPTION
This is the next set of the App API backfill, which adds the broadcast endpoints to `APIClient`.

## New methods (13)

`listBroadcasts`, `getBroadcast`, `getBroadcastActions`, `getBroadcastAction`, `updateBroadcastAction`, `getBroadcastActionLanguage`, `updateBroadcastActionLanguage`, `getBroadcastActionMetrics`, `getBroadcastActionMetricsLinks`, `getBroadcastMetrics`, `getBroadcastMetricsLinks`, `getBroadcastMessages`, `getBroadcastTriggers`.

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface and documentation with established patterns; PUT update methods are tested in unit tests only in live runs, limiting production mutation risk.
> 
> **Overview**
> Extends **`APIClient`** with **13 broadcast App API methods** (list/get broadcast, actions, localized action content, metrics, messages, and triggers), calling **`/broadcasts/...`** via the existing **`resourceBase('broadcasts', ...)`** helper.
> 
> Adds shared **`DeliveryState`** and **`BroadcastMessagesOptions`** types (transactional delivery listing now uses **`DeliveryState`** too). **`docs/app.md`** documents the new methods; **`test/api.ts`** covers URLs, query params, and validation; **`test/integration/live.ts`** adds read-only live checks (mutating action updates stay unit-tested only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f952976518641f6a250f393ff3e443315164911e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->