### PR TITLE
Dedicated `ObjectFilter` type + top-level `not` filter support

### DIFF
--- a/lib/api.ts
+++ b/lib/api.ts
@@ -9,7 +9,7 @@ import {
   SendInAppRequest,
 } from './api/requests';
 import { isEmpty, isIdentifierType, isObjectIdType, buildQueryString, MissingParamError } from './utils';
-import type { Filter } from './types';
+import type { Filter, ObjectFilter } from './types';
 import { IdentifierType } from './types';
 
 /** Which identifier kind the values in an object endpoint refer to. */
@@ -760,19 +760,13 @@ export class APIClient {
    * Find objects of a given type matching a filter.
    *
    * @param objectTypeId The object type's numeric id.
-   * @param filter A filter expression (and/or/not).
+   * @param filter An {@link ObjectFilter} expression — `object_attribute` leaf
+   *   conditions composed with `and` / `or` / `not`.
    * @param options Optional pagination. See {@link PaginationOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `objectTypeId` is empty or `filter` is `null`/`undefined`.
-   *
-   * @remarks
-   * The object filter schema differs from the audience {@link Filter} (it uses
-   * `object_attribute` conditions with a `type_id` and has no `segment`). A
-   * dedicated `ObjectFilter` type (plus top-level `not` support for both
-   * filters) is tracked as a follow-up; for now `filter` is typed loosely as
-   * `Record<string, any>` to avoid implying the audience shape is accepted.
    */
-  findObjects(objectTypeId: string | number, filter: Record<string, any>, options: PaginationOptions = {}) {
+  findObjects(objectTypeId: string | number, filter: ObjectFilter, options: PaginationOptions = {}) {
     if (isEmpty(objectTypeId)) {
       throw new MissingParamError('objectTypeId');
     }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -11,45 +11,66 @@ export enum IdentifierType {
   CioId = 'cio_id',
 }
 
-/** Comparison operators supported in {@link AttributeFilter}. */
+/** Comparison operators supported in attribute and object conditions. */
 export enum FilterOperator {
   Eq = 'eq',
   Exists = 'exists',
 }
 
-/** Filter matching everyone in a given segment. */
-export type SegmentFilter = {
-  id: number;
+/** A leaf condition matching everyone in a given segment. */
+export type SegmentCondition = {
+  segment: { id: number };
 };
 
-/** Filter matching people whose attribute satisfies an operator/value. */
-export type AttributeFilter = {
-  field: string;
-  operator: FilterOperator;
-  value?: string;
-};
-
-/** Negation of either a segment or attribute filter. */
-export type NotFilter = {
-  segment?: SegmentFilter;
-  attribute?: AttributeFilter;
-};
-
-/** Union of the leaf filter shapes that compose larger boolean filters. */
-export type FilterObject = SegmentFilter | AttributeFilter | NotFilter;
-
-/** All sub-filters must match. */
-export type AndFilter = {
-  and: FilterObject[];
-};
-
-/** At least one sub-filter must match. */
-export type OrFilter = {
-  or: FilterObject[];
+/** A leaf condition matching people whose attribute satisfies an operator/value. */
+export type AttributeCondition = {
+  attribute: {
+    field: string;
+    operator: FilterOperator;
+    value?: string;
+  };
 };
 
 /**
- * Top-level filter expression. Compose with {@link AndFilter} / {@link OrFilter}
- * and nest {@link SegmentFilter}, {@link AttributeFilter}, or {@link NotFilter}.
+ * An audience (people) filter expression. Compose `segment` and `attribute`
+ * leaf conditions with `and` / `or` / `not` (each may nest arbitrarily).
+ *
+ * Used by {@link https://customer.io/docs/api/app/#operation/getCustomersByFilter searchCustomers}
+ * and delivery/customer exports.
  */
-export type Filter = AndFilter | OrFilter;
+export type AudienceFilter =
+  | SegmentCondition
+  | AttributeCondition
+  | { and: AudienceFilter[] }
+  | { or: AudienceFilter[] }
+  | { not: AudienceFilter };
+
+/**
+ * Backwards-compatible alias for {@link AudienceFilter}, the people-filter
+ * expression accepted by `searchCustomers` and `createCustomersExport`.
+ */
+export type Filter = AudienceFilter;
+
+/**
+ * A leaf condition matching objects whose attribute satisfies an operator/value.
+ * `type_id` (the object type) is required by the API.
+ */
+export type ObjectAttributeCondition = {
+  object_attribute: {
+    field: string;
+    operator: FilterOperator;
+    value?: string;
+    type_id: number;
+  };
+};
+
+/**
+ * An object filter expression. Compose `object_attribute` leaf conditions with
+ * `and` / `or` / `not`. Unlike {@link AudienceFilter}, it has no `segment`
+ * conditions. Used by `findObjects`.
+ */
+export type ObjectFilter =
+  | ObjectAttributeCondition
+  | { and: ObjectFilter[] }
+  | { or: ObjectFilter[] }
+  | { not: ObjectFilter };

--- a/test/api.ts
+++ b/test/api.ts
@@ -13,8 +13,8 @@ import {
   SendInAppRequest,
 } from '../lib/api';
 import { RegionUS, RegionEU } from '../lib/regions';
-import type { Filter } from '../lib/types';
-import { IdentifierType } from '../lib/types';
+import type { Filter, ObjectFilter } from '../lib/types';
+import { IdentifierType, FilterOperator } from '../lib/types';
 
 type TestContext = { client: APIClient };
 
@@ -978,11 +978,29 @@ test('#getObjectRelationships: paginates the object relationships path', (t) => 
 
 test('#findObjects: posts object_type_id + filter with pagination', (t) => {
   const post = sinon.stub(t.context.client.request, 'post');
-  const filter = { and: [{ object_attribute: { field: 'name', operator: 'eq', value: 'acme', type_id: 1 } }] };
+  const filter: ObjectFilter = {
+    and: [{ object_attribute: { field: 'name', operator: FilterOperator.Eq, value: 'acme', type_id: 1 } }],
+  };
   t.throws(() => t.context.client.findObjects('', filter), { message: 'objectTypeId is required' });
   t.throws(() => (t.context.client.findObjects as any)(1, null), { message: 'filter is required' });
   t.context.client.findObjects(1, filter, { start: 'c' });
   t.true(post.calledWith(`${API}/objects?start=c`, { object_type_id: 1, filter }));
+});
+
+test('#findObjects: accepts a top-level not object filter', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const filter: ObjectFilter = {
+    not: { object_attribute: { field: 'archived', operator: FilterOperator.Exists, type_id: 1 } },
+  };
+  t.context.client.findObjects(1, filter);
+  t.true(post.calledWith(`${API}/objects`, { object_type_id: 1, filter }));
+});
+
+test('#searchCustomers: accepts a top-level not audience filter', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  const filter: Filter = { not: { segment: { id: 7 } } };
+  t.context.client.searchCustomers(filter);
+  t.true(post.calledWith(`${API}/customers`, { filter }));
 });
 
 test('#listObjectTypes: gets the object_types endpoint', (t) => {

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -42,7 +42,7 @@ import {
   SendInboxMessageRequest,
 } from '../../lib/api/requests';
 import { RegionUS, RegionEU } from '../../lib/regions';
-import { IdentifierType } from '../../lib/types';
+import { FilterOperator, IdentifierType } from '../../lib/types';
 
 const isLive = process.env.CIO_LIVE === '1';
 const siteId = process.env.CIO_SITE_ID ?? '';
@@ -137,8 +137,8 @@ liveTest('getCustomersAttributes returns attributes for the profile', async (t) 
 
 liveTest('searchCustomers resolves against an attribute filter', async (t) => {
   const filter = {
-    and: [{ attribute: { field: 'plan', operator: 'eq', value: 'sdk-test' } }],
-  } as unknown as Parameters<APIClient['searchCustomers']>[0];
+    and: [{ attribute: { field: 'plan', operator: FilterOperator.Eq, value: 'sdk-test' } }],
+  };
   const result = (await api!.searchCustomers(filter, { limit: 10 })) as Record<string, unknown>;
   t.truthy(result);
 });
@@ -164,8 +164,8 @@ needs('CIO_TEST_OBJECT_TYPE_ID')('object attribute + relationship reads resolve'
 needs('CIO_TEST_OBJECT_TYPE_ID')('findObjects resolves for a test object type', async (t) => {
   const typeId = process.env.CIO_TEST_OBJECT_TYPE_ID!;
   const filter = {
-    and: [{ object_attribute: { field: 'name', operator: 'exists', type_id: Number(typeId) } }],
-  } as unknown as Parameters<APIClient['findObjects']>[1];
+    and: [{ object_attribute: { field: 'name', operator: FilterOperator.Exists, type_id: Number(typeId) } }],
+  };
   const result = (await api!.findObjects(typeId, filter, { limit: 5 })) as Record<string, unknown>;
   t.truthy(result);
 });
@@ -393,7 +393,7 @@ needs('CIO_TEST_BROADCAST_ID')('triggerBroadcast resolves against a test broadca
 });
 
 liveTest('createCustomersExport queues an export', async (t) => {
-  const filters = { or: [{ segment: { id: 0 } }] } as unknown as Parameters<APIClient['createCustomersExport']>[0];
+  const filters = { or: [{ segment: { id: 0 } }] };
   const result = (await api!.createCustomersExport(filters)) as { export?: { id: number } };
   t.truthy(result.export);
 });

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -165,7 +165,7 @@ needs('CIO_TEST_OBJECT_TYPE_ID')('findObjects resolves for a test object type', 
   const typeId = process.env.CIO_TEST_OBJECT_TYPE_ID!;
   const filter = {
     and: [{ object_attribute: { field: 'name', operator: 'exists', type_id: Number(typeId) } }],
-  };
+  } as unknown as Parameters<APIClient['findObjects']>[1];
   const result = (await api!.findObjects(typeId, filter, { limit: 5 })) as Record<string, unknown>;
   t.truthy(result);
 });


### PR DESCRIPTION
Follow-up from #228. This refactors the filter types to match the App API's two distinct filter schemas and adds top-level `not`.

- **`AudienceFilter`** (people) — `segment` / `attribute` leaf conditions composed with `and` / `or` / `not`. `Filter` is kept as an alias, so `searchCustomers` / `createCustomersExport` callers are unaffected.
- **`ObjectFilter`** (objects) — `object_attribute` leaf conditions (with required `type_id`, no `segment`) composed with `and` / `or` / `not`. `findObjects` now takes `ObjectFilter` instead of `Record<string, any>`.
- **Correctly-wrapped leaf shapes** — `{ segment: { id } }`, `{ attribute: {…} }`, `{ object_attribute: {…} }` — replacing the previous mislabeled/loose `SegmentFilter` / `AttributeFilter` / `NotFilter` / `FilterObject` / `AndFilter` / `OrFilter`.
- Added unit tests for the top-level `not` case on both filters.

## ⚠️ Breaking (types only — no runtime change)

Removed exported types: `SegmentFilter`, `AttributeFilter`, `NotFilter`, `FilterObject`, `AndFilter`, `OrFilter`. Added: `SegmentCondition`, `AttributeCondition`, `AudienceFilter`, `ObjectAttributeCondition`, `ObjectFilter`. `Filter` remains as an alias of `AudienceFilter`.

Code that builds `and`/`or`/`segment`/`attribute` object literals is unaffected; only code importing the removed type names must update. **Intended to ship as a minor release with a Breaking note in the changelog.**

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Types-only breaking change for consumers importing removed filter type names; `findObjects` is now strictly typed, which may surface compile errors but does not change request payloads.
> 
> **Overview**
> Refactors App API filter types to match **people** vs **object** schemas and tightens typings with no runtime behavior change.
> 
> **`lib/types.ts`** introduces **`AudienceFilter`** (`segment` / `attribute` leaves + `and` / `or` / `not`) with **`Filter`** kept as an alias for `searchCustomers` and `createCustomersExport`. **`ObjectFilter`** adds `object_attribute` leaves (required `type_id`, no segments) with the same boolean combinators. Leaf shapes are now API-aligned wrappers (`{ segment: { id } }`, `{ attribute: {…} }`, `{ object_attribute: {…} }`). Several old exported names (`SegmentFilter`, `AttributeFilter`, `AndFilter`, `OrFilter`, etc.) are **removed** — a **types-only breaking** change for importers of those symbols.
> 
> **`findObjects`** now accepts **`ObjectFilter`** instead of `Record<string, any>`. Unit tests cover top-level **`not`** for both audience and object filters; integration tests use **`FilterOperator`** and drop unnecessary type casts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65c1ef1fab59f49b14ab6379051448a7fdced32c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->