### PR TITLE
Add App API newsletter core methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -984,15 +984,21 @@ api.listNewsletters({ limit: 25, sort: "desc" });
 
 ### api.createNewsletter(data)
 
-Create a newsletter.
+Create a newsletter. Both `name` and `recipients` (an audience filter) are required.
 
 ```javascript
-api.createNewsletter({ name: "Weekly digest" });
+api.createNewsletter({
+  name: "Weekly digest",
+  recipients: { segment: { id: 7 } },
+});
 ```
 
 #### Options
 
 - **data**: The newsletter definition
+  - _name_: The newsletter's name, ≤190 characters (required)
+  - _recipients_: An audience filter selecting who receives the newsletter (required)
+  - Additional fields may be required depending on configuration (e.g. channel-specific `subject`/`body`, or `subscription_topic_id` when the subscription center is enabled)
 
 ### api.getNewsletter(newsletterId)
 
@@ -1062,41 +1068,41 @@ api.updateNewsletterContent(8, 3, { subject: "Updated subject" });
 Get metrics for a single newsletter content variant over time.
 
 ```javascript
-api.getNewsletterContentMetrics(8, 3, { period: "days", steps: 7, type: "email" });
+api.getNewsletterContentMetrics(8, 3, { period: "days", steps: 7 });
 ```
 
 #### Options
 
 - **newsletterId**: The newsletter's numeric id (required)
 - **contentId**: The content variant's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type` ("email" / "webhook" / "twilio" / "push" / "in_app" / "inbox")
+- **options**: Object (optional) — `period`, `steps` (newsletter metrics are always aggregated across all channels)
 
 ### api.getNewsletterContentMetricsLinks(newsletterId, contentId, options)
 
 Get link (click) metrics for a single newsletter content variant over time.
 
 ```javascript
-api.getNewsletterContentMetricsLinks(8, 3, { period: "weeks", steps: 4, type: "email" });
+api.getNewsletterContentMetricsLinks(8, 3, { period: "weeks", steps: 4, unique: true });
 ```
 
 #### Options
 
 - **newsletterId**: The newsletter's numeric id (required)
 - **contentId**: The content variant's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type`
+- **options**: Object (optional) — `period`, `steps`, `unique`
 
 ### api.getNewsletterMetrics(newsletterId, options)
 
 Get delivery metrics for a newsletter over time.
 
 ```javascript
-api.getNewsletterMetrics(8, { period: "days", steps: 30, type: "email" });
+api.getNewsletterMetrics(8, { period: "days", steps: 30 });
 ```
 
 #### Options
 
 - **newsletterId**: The newsletter's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type`
+- **options**: Object (optional) — `period`, `steps` (newsletter metrics are always aggregated across all channels)
 
 ### api.getNewsletterMetricsLinks(newsletterId, options)
 
@@ -1122,7 +1128,7 @@ api.getNewsletterMessages(8, { metric: "delivered", limit: 50 });
 #### Options
 
 - **newsletterId**: The newsletter's numeric id (required)
-- **options**: Object (optional) — `start`, `limit`, `metric`, `start_ts`, `end_ts`, `get_tracked_responses`
+- **options**: Object (optional) — `start`, `limit`, `metric`, `type` ("email" / "webhook" / "twilio" / "push" / "in_app" / "inbox"), `start_ts`, `end_ts`, `get_tracked_responses`
 
 ### api.sendNewsletter(newsletterId, data)
 
@@ -1139,13 +1145,16 @@ api.sendNewsletter(8, { rate_limit_email_rate: 100, rate_limit_time_period: 60 }
 
 ### api.scheduleNewsletter(newsletterId, data)
 
-Schedule a newsletter to send later.
+Schedule a newsletter to send later. `scheduled_at` (a Unix timestamp) and `timezone` are both required.
 
 ```javascript
-api.scheduleNewsletter(8, { timestamp: 1719792000 });
+api.scheduleNewsletter(8, { scheduled_at: 1719792000, timezone: "America/New_York" });
 ```
 
 #### Options
 
 - **newsletterId**: The newsletter's numeric id (required)
 - **data**: The schedule settings
+  - _scheduled_at_: Unix timestamp (seconds) when the newsletter should send (required, must be in the future)
+  - _timezone_: IANA timezone the scheduled time is expressed in (required)
+  - Optional: `tz_match_enabled`, `rate_limit_email_rate`, `rate_limit_time_period`, `rate_limit_spread`

--- a/docs/app.md
+++ b/docs/app.md
@@ -1158,3 +1158,139 @@ api.scheduleNewsletter(8, { scheduled_at: 1719792000, timezone: "America/New_Yor
   - _scheduled_at_: Unix timestamp (seconds) when the newsletter should send (required, must be in the future)
   - _timezone_: IANA timezone the scheduled time is expressed in (required)
   - Optional: `tz_match_enabled`, `rate_limit_email_rate`, `rate_limit_time_period`, `rate_limit_spread`
+
+### api.createNewsletterLanguage(newsletterId, data)
+
+Add a language (translation) to a newsletter. `language` is required, and the required content fields depend on the newsletter's channel (e.g. an email newsletter requires `subject` and `body`).
+
+```javascript
+api.createNewsletterLanguage(8, { language: "fr", subject: "Bonjour", body: "<p>Bonjour&nbsp;!</p>" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **data**: The translation content
+  - _language_: The IETF language tag (required)
+  - _subject_ / _body_: Required for email; other channels require their own fields (e.g. `body_json` for in-app/inbox, `body` for SMS/webhook)
+
+### api.getNewsletterLanguage(newsletterId, language)
+
+Get a single-language translation of a newsletter.
+
+```javascript
+api.getNewsletterLanguage(8, "en-US");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateNewsletterLanguage(newsletterId, language, data)
+
+Update a single-language translation of a newsletter.
+
+```javascript
+api.updateNewsletterLanguage(8, "fr", { subject: "Salut" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.deleteNewsletterLanguage(newsletterId, language)
+
+Delete a single-language translation of a newsletter.
+
+```javascript
+api.deleteNewsletterLanguage(8, "fr");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.getNewsletterTestGroups(newsletterId)
+
+List a newsletter's A/B test groups.
+
+```javascript
+api.getNewsletterTestGroups(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.createNewsletterTestGroup(newsletterId)
+
+Create an A/B test group on a newsletter. The API takes no request body — a new empty test group is created.
+
+```javascript
+api.createNewsletterTestGroup(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.createNewsletterTestGroupLanguage(newsletterId, testGroupId, data)
+
+Add a language (translation) to a newsletter test group. Same content requirements as `createNewsletterLanguage` (`language` required, plus channel-specific fields such as `subject`/`body` for email).
+
+```javascript
+api.createNewsletterTestGroupLanguage(8, 2, { language: "fr", subject: "Bonjour", body: "<p>Bonjour&nbsp;!</p>" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **data**: The translation content (`language` required; channel-specific content fields required)
+
+### api.getNewsletterTestGroupLanguage(newsletterId, testGroupId, language)
+
+Get a single-language translation of a newsletter test group.
+
+```javascript
+api.getNewsletterTestGroupLanguage(8, 2, "en-US");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateNewsletterTestGroupLanguage(newsletterId, testGroupId, language, data)
+
+Update a single-language translation of a newsletter test group.
+
+```javascript
+api.updateNewsletterTestGroupLanguage(8, 2, "fr", { subject: "Salut" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.deleteNewsletterTestGroupLanguage(newsletterId, testGroupId, language)
+
+Delete a single-language translation of a newsletter test group.
+
+```javascript
+api.deleteNewsletterTestGroupLanguage(8, 2, "fr");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)

--- a/docs/app.md
+++ b/docs/app.md
@@ -969,3 +969,183 @@ api.getBroadcastTriggers(4);
 #### Options
 
 - **broadcastId**: The broadcast's numeric id (required)
+
+### api.listNewsletters(options)
+
+List the newsletters in your workspace.
+
+```javascript
+api.listNewsletters({ limit: 25, sort: "desc" });
+```
+
+#### Options
+
+- **options**: Object (optional) — `start`, `limit`, `sort` ("asc" / "desc")
+
+### api.createNewsletter(data)
+
+Create a newsletter.
+
+```javascript
+api.createNewsletter({ name: "Weekly digest" });
+```
+
+#### Options
+
+- **data**: The newsletter definition
+
+### api.getNewsletter(newsletterId)
+
+Get a single newsletter's metadata.
+
+```javascript
+api.getNewsletter(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.deleteNewsletter(newsletterId)
+
+Delete a newsletter.
+
+```javascript
+api.deleteNewsletter(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.getNewsletterContents(newsletterId)
+
+List all content variants of a newsletter.
+
+```javascript
+api.getNewsletterContents(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.getNewsletterContent(newsletterId, contentId)
+
+Get a single content variant of a newsletter.
+
+```javascript
+api.getNewsletterContent(8, 3);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **contentId**: The content variant's numeric id (required)
+
+### api.updateNewsletterContent(newsletterId, contentId, data)
+
+Update a content variant of a newsletter.
+
+```javascript
+api.updateNewsletterContent(8, 3, { subject: "Updated subject" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **contentId**: The content variant's numeric id (required)
+- **data**: The content fields to update
+
+### api.getNewsletterContentMetrics(newsletterId, contentId, options)
+
+Get metrics for a single newsletter content variant over time.
+
+```javascript
+api.getNewsletterContentMetrics(8, 3, { period: "days", steps: 7, type: "email" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **contentId**: The content variant's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type` ("email" / "webhook" / "twilio" / "push" / "in_app" / "inbox")
+
+### api.getNewsletterContentMetricsLinks(newsletterId, contentId, options)
+
+Get link (click) metrics for a single newsletter content variant over time.
+
+```javascript
+api.getNewsletterContentMetricsLinks(8, 3, { period: "weeks", steps: 4, type: "email" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **contentId**: The content variant's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getNewsletterMetrics(newsletterId, options)
+
+Get delivery metrics for a newsletter over time.
+
+```javascript
+api.getNewsletterMetrics(8, { period: "days", steps: 30, type: "email" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `type`
+
+### api.getNewsletterMetricsLinks(newsletterId, options)
+
+Get link (click) metrics for a newsletter over time.
+
+```javascript
+api.getNewsletterMetricsLinks(8, { period: "days", steps: 30, unique: true });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **options**: Object (optional) — `period`, `steps`, `unique`
+
+### api.getNewsletterMessages(newsletterId, options)
+
+Get the individual messages (deliveries) sent by a newsletter.
+
+```javascript
+api.getNewsletterMessages(8, { metric: "delivered", limit: 50 });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **options**: Object (optional) — `start`, `limit`, `metric`, `start_ts`, `end_ts`, `get_tracked_responses`
+
+### api.sendNewsletter(newsletterId, data)
+
+Send a newsletter.
+
+```javascript
+api.sendNewsletter(8, { rate_limit_email_rate: 100, rate_limit_time_period: 60 });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **data**: Optional send settings — `rate_limit_email_rate`, `rate_limit_time_period`, `rate_limit_spread`
+
+### api.scheduleNewsletter(newsletterId, data)
+
+Schedule a newsletter to send later.
+
+```javascript
+api.scheduleNewsletter(8, { timestamp: 1719792000 });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **data**: The schedule settings

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -206,24 +206,29 @@ export type ListNewslettersOptions = PaginationOptions & {
 };
 
 /**
- * Message channel a newsletter metric query can be scoped to. Newsletters
- * support a slightly different channel set than campaigns/broadcasts (notably
- * `inbox`, and no `whatsapp`/`slack`).
+ * Message channel a newsletter can be scoped to. Newsletters support a slightly
+ * different channel set than campaigns/broadcasts (notably `inbox`, and no
+ * `whatsapp`/`slack`).
  */
-export type NewsletterMetricType = 'email' | 'webhook' | 'twilio' | 'push' | 'in_app' | 'inbox';
+export type NewsletterChannelType = 'email' | 'webhook' | 'twilio' | 'push' | 'in_app' | 'inbox';
 
-/** Options for newsletter metric reports (newsletter + content level). */
+/**
+ * Options for newsletter metric reports (newsletter + content level).
+ *
+ * Note: newsletter metrics are always aggregated across all channels — the API
+ * does not accept a channel `type` filter here (unlike campaigns/broadcasts).
+ */
 export type NewsletterMetricsOptions = {
   period?: MetricsPeriod;
   steps?: number;
-  /** Scope the report to a single channel. */
-  type?: NewsletterMetricType;
 };
 
 /** Options for {@link APIClient.getNewsletterMessages}. */
 export type NewsletterMessagesOptions = PaginationOptions & {
   /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
   metric?: string;
+  /** Scope to a single channel. */
+  type?: NewsletterChannelType;
   /** Only include deliveries after this Unix timestamp (seconds). */
   start_ts?: number;
   /** Only include deliveries before this Unix timestamp (seconds). */
@@ -1966,7 +1971,7 @@ export class APIClient {
       throw new MissingParamError('contentId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps });
 
     return this.request.get(
       `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}/metrics${query}`,
@@ -1978,14 +1983,14 @@ export class APIClient {
    *
    * @param newsletterId The newsletter's numeric id.
    * @param contentId The content variant's numeric id.
-   * @param options Optional reporting window/filters. See {@link NewsletterMetricsOptions}.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `newsletterId` or `contentId` is empty.
    */
   getNewsletterContentMetricsLinks(
     newsletterId: string | number,
     contentId: string | number,
-    options: NewsletterMetricsOptions = {},
+    options: LinkMetricsOptions = {},
   ) {
     if (isEmpty(newsletterId)) {
       throw new MissingParamError('newsletterId');
@@ -1995,7 +2000,7 @@ export class APIClient {
       throw new MissingParamError('contentId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
 
     return this.request.get(
       `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}/metrics/links${query}`,
@@ -2015,7 +2020,7 @@ export class APIClient {
       throw new MissingParamError('newsletterId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps });
 
     return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/metrics${query}`);
   }
@@ -2055,6 +2060,7 @@ export class APIClient {
       start: options.start,
       limit: options.limit,
       metric: options.metric,
+      type: options.type,
       start_ts: options.start_ts,
       end_ts: options.end_ts,
       get_tracked_responses: options.get_tracked_responses,

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -196,6 +196,42 @@ export type BroadcastMessagesOptions = PaginationOptions & {
   get_tracked_responses?: boolean;
 };
 
+/** Sort direction for list endpoints that support it. */
+export type SortDirection = 'asc' | 'desc';
+
+/** Options for {@link APIClient.listNewsletters}. */
+export type ListNewslettersOptions = PaginationOptions & {
+  /** Sort order by creation time. */
+  sort?: SortDirection;
+};
+
+/**
+ * Message channel a newsletter metric query can be scoped to. Newsletters
+ * support a slightly different channel set than campaigns/broadcasts (notably
+ * `inbox`, and no `whatsapp`/`slack`).
+ */
+export type NewsletterMetricType = 'email' | 'webhook' | 'twilio' | 'push' | 'in_app' | 'inbox';
+
+/** Options for newsletter metric reports (newsletter + content level). */
+export type NewsletterMetricsOptions = {
+  period?: MetricsPeriod;
+  steps?: number;
+  /** Scope the report to a single channel. */
+  type?: NewsletterMetricType;
+};
+
+/** Options for {@link APIClient.getNewsletterMessages}. */
+export type NewsletterMessagesOptions = PaginationOptions & {
+  /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
+  metric?: string;
+  /** Only include deliveries after this Unix timestamp (seconds). */
+  start_ts?: number;
+  /** Only include deliveries before this Unix timestamp (seconds). */
+  end_ts?: number;
+  /** When `true`, include tracked responses on each delivery. */
+  get_tracked_responses?: boolean;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -1141,7 +1177,7 @@ export class APIClient {
    * Build the base URL for a campaign/broadcast resource. Shared by the
    * campaign and broadcast methods, which have identical sub-resource paths.
    */
-  private resourceBase(resource: 'campaigns' | 'broadcasts', id: string | number) {
+  private resourceBase(resource: 'campaigns' | 'broadcasts' | 'newsletters', id: string | number) {
     return `${this.apiRoot}/${resource}/${encodeURIComponent(id)}`;
   }
 
@@ -1793,6 +1829,271 @@ export class APIClient {
     }
 
     return this.request.get(`${this.resourceBase('broadcasts', broadcastId)}/triggers`);
+  }
+
+  /**
+   * List the newsletters in your workspace.
+   *
+   * @param options Optional pagination and sort. See {@link ListNewslettersOptions}.
+   * @returns The parsed JSON response body (`{ newsletters: [...], next }`).
+   */
+  listNewsletters(options: ListNewslettersOptions = {}) {
+    const query = buildQueryString({ start: options.start, limit: options.limit, sort: options.sort });
+
+    return this.request.get(`${this.apiRoot}/newsletters${query}`);
+  }
+
+  /**
+   * Create a newsletter.
+   *
+   * @param data The newsletter definition.
+   * @returns The parsed JSON response body.
+   */
+  createNewsletter(data: RequestData = {}) {
+    return this.request.post(`${this.apiRoot}/newsletters`, data);
+  }
+
+  /**
+   * Get a single newsletter's metadata.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletter(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.get(this.resourceBase('newsletters', newsletterId));
+  }
+
+  /**
+   * Delete a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  deleteNewsletter(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.destroy(this.resourceBase('newsletters', newsletterId));
+  }
+
+  /**
+   * List all content variants of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterContents(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/contents`);
+  }
+
+  /**
+   * Get a single content variant of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param contentId The content variant's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `contentId` is empty.
+   */
+  getNewsletterContent(newsletterId: string | number, contentId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(contentId)) {
+      throw new MissingParamError('contentId');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}`,
+    );
+  }
+
+  /**
+   * Update a content variant of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param contentId The content variant's numeric id.
+   * @param data The content fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `contentId` is empty.
+   */
+  updateNewsletterContent(newsletterId: string | number, contentId: string | number, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(contentId)) {
+      throw new MissingParamError('contentId');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}`,
+      data,
+    );
+  }
+
+  /**
+   * Get metrics for a single newsletter content variant over time.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param contentId The content variant's numeric id.
+   * @param options Optional reporting window/filters. See {@link NewsletterMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `contentId` is empty.
+   */
+  getNewsletterContentMetrics(
+    newsletterId: string | number,
+    contentId: string | number,
+    options: NewsletterMetricsOptions = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(contentId)) {
+      throw new MissingParamError('contentId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}/metrics${query}`,
+    );
+  }
+
+  /**
+   * Get link (click) metrics for a single newsletter content variant over time.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param contentId The content variant's numeric id.
+   * @param options Optional reporting window/filters. See {@link NewsletterMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `contentId` is empty.
+   */
+  getNewsletterContentMetricsLinks(
+    newsletterId: string | number,
+    contentId: string | number,
+    options: NewsletterMetricsOptions = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(contentId)) {
+      throw new MissingParamError('contentId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/contents/${encodeURIComponent(contentId)}/metrics/links${query}`,
+    );
+  }
+
+  /**
+   * Get delivery metrics for a newsletter over time.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param options Optional reporting window/filters. See {@link NewsletterMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterMetrics(newsletterId: string | number, options: NewsletterMetricsOptions = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/metrics${query}`);
+  }
+
+  /**
+   * Get link (click) metrics for a newsletter over time.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterMetricsLinks(newsletterId: string | number, options: LinkMetricsOptions = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/metrics/links${query}`);
+  }
+
+  /**
+   * Get the individual messages (deliveries) sent by a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param options Optional filters/pagination. See {@link NewsletterMessagesOptions}.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterMessages(newsletterId: string | number, options: NewsletterMessagesOptions = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    const query = buildQueryString({
+      start: options.start,
+      limit: options.limit,
+      metric: options.metric,
+      start_ts: options.start_ts,
+      end_ts: options.end_ts,
+      get_tracked_responses: options.get_tracked_responses,
+    });
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/messages${query}`);
+  }
+
+  /**
+   * Send a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param data Optional send settings — e.g. `rate_limit_email_rate`,
+   *   `rate_limit_time_period`, `rate_limit_spread`.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  sendNewsletter(newsletterId: string | number, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/send`, data);
+  }
+
+  /**
+   * Schedule a newsletter to send later.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param data The schedule settings.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  scheduleNewsletter(newsletterId: string | number, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/schedule`, data);
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2101,6 +2101,237 @@ export class APIClient {
 
     return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/schedule`, data);
   }
+
+  /**
+   * Add a language (translation) to a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param data The translation content, including its `language` tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  createNewsletterLanguage(newsletterId: string | number, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/language`, data);
+  }
+
+  /**
+   * Get a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  getNewsletterLanguage(newsletterId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  updateNewsletterLanguage(newsletterId: string | number, language: string, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Delete a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  deleteNewsletterLanguage(newsletterId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.destroy(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * List a newsletter's A/B test groups.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterTestGroups(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/test_groups`);
+  }
+
+  /**
+   * Create an A/B test group on a newsletter. The API takes no request body —
+   * a new empty test group is created and returned.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body (the updated newsletter).
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  createNewsletterTestGroup(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/test_groups`);
+  }
+
+  /**
+   * Add a language (translation) to a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param data The translation content, including its `language` tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `testGroupId` is empty.
+   */
+  createNewsletterTestGroupLanguage(
+    newsletterId: string | number,
+    testGroupId: string | number,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    return this.request.post(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language`,
+      data,
+    );
+  }
+
+  /**
+   * Get a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  getNewsletterTestGroupLanguage(newsletterId: string | number, testGroupId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  updateNewsletterTestGroupLanguage(
+    newsletterId: string | number,
+    testGroupId: string | number,
+    language: string,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Delete a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  deleteNewsletterTestGroupLanguage(newsletterId: string | number, testGroupId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.destroy(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
 }
 
 export {

--- a/test/api.ts
+++ b/test/api.ts
@@ -1424,3 +1424,115 @@ test('#getBroadcastTriggers: gets the triggers endpoint and validates', (t) => {
   t.context.client.getBroadcastTriggers(4);
   t.true(get.calledWith(`${API}/broadcasts/4/triggers`));
 });
+
+// --- Batch 6: Newsletters — core (CDP-6270) ---
+
+test('#listNewsletters: forwards pagination + sort', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listNewsletters();
+  t.true(get.calledWith(`${API}/newsletters`));
+  t.context.client.listNewsletters({ start: 'c', limit: 25, sort: 'desc' });
+  t.true(get.calledWith(`${API}/newsletters?start=c&limit=25&sort=desc`));
+});
+
+test('#createNewsletter: posts the body', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.context.client.createNewsletter({ name: 'Weekly' });
+  t.true(post.calledWith(`${API}/newsletters`, { name: 'Weekly' }));
+  t.context.client.createNewsletter();
+  t.true(post.calledWith(`${API}/newsletters`, {}));
+});
+
+test('#getNewsletter: gets one and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletter(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletter(8);
+  t.true(get.calledWith(`${API}/newsletters/8`));
+});
+
+test('#deleteNewsletter: deletes and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteNewsletter(''), { message: 'newsletterId is required' });
+  t.context.client.deleteNewsletter(8);
+  t.true(destroy.calledWith(`${API}/newsletters/8`));
+});
+
+test('#getNewsletterContents: lists contents and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterContents(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterContents(8);
+  t.true(get.calledWith(`${API}/newsletters/8/contents`));
+});
+
+test('#getNewsletterContent: gets one content and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterContent('', 3), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterContent(8, ''), { message: 'contentId is required' });
+  t.context.client.getNewsletterContent(8, 3);
+  t.true(get.calledWith(`${API}/newsletters/8/contents/3`));
+});
+
+test('#updateNewsletterContent: puts the body and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateNewsletterContent('', 3, {}), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.updateNewsletterContent(8, '', {}), { message: 'contentId is required' });
+  t.context.client.updateNewsletterContent(8, 3, { subject: 'Hi' });
+  t.true(put.calledWith(`${API}/newsletters/8/contents/3`, { subject: 'Hi' }));
+  t.context.client.updateNewsletterContent(8, 3);
+  t.true(put.calledWith(`${API}/newsletters/8/contents/3`, {}));
+});
+
+test('#getNewsletterContentMetrics: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterContentMetrics('', 3), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterContentMetrics(8, ''), { message: 'contentId is required' });
+  t.context.client.getNewsletterContentMetrics(8, 3, { period: 'days', steps: 7, type: 'inbox' });
+  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics?period=days&steps=7&type=inbox`));
+});
+
+test('#getNewsletterContentMetricsLinks: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterContentMetricsLinks('', 3), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterContentMetricsLinks(8, ''), { message: 'contentId is required' });
+  t.context.client.getNewsletterContentMetricsLinks(8, 3, { period: 'weeks', steps: 4, type: 'email' });
+  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics/links?period=weeks&steps=4&type=email`));
+});
+
+test('#getNewsletterMetrics: forwards options and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterMetrics(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterMetrics(8, { period: 'days', steps: 30, type: 'email' });
+  t.true(get.calledWith(`${API}/newsletters/8/metrics?period=days&steps=30&type=email`));
+});
+
+test('#getNewsletterMetricsLinks: forwards unique and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterMetricsLinks(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterMetricsLinks(8, { period: 'days', steps: 30, unique: true });
+  t.true(get.calledWith(`${API}/newsletters/8/metrics/links?period=days&steps=30&unique=true`));
+});
+
+test('#getNewsletterMessages: forwards filters and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterMessages(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterMessages(8, { metric: 'delivered', limit: 50, get_tracked_responses: true });
+  t.true(get.calledWith(`${API}/newsletters/8/messages?limit=50&metric=delivered&get_tracked_responses=true`));
+});
+
+test('#sendNewsletter: posts send settings and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.sendNewsletter(''), { message: 'newsletterId is required' });
+  t.context.client.sendNewsletter(8, { rate_limit_email_rate: 100 });
+  t.true(post.calledWith(`${API}/newsletters/8/send`, { rate_limit_email_rate: 100 }));
+  t.context.client.sendNewsletter(8);
+  t.true(post.calledWith(`${API}/newsletters/8/send`, {}));
+});
+
+test('#scheduleNewsletter: posts schedule settings and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.scheduleNewsletter(''), { message: 'newsletterId is required' });
+  t.context.client.scheduleNewsletter(8, { timestamp: 1719792000 });
+  t.true(post.calledWith(`${API}/newsletters/8/schedule`, { timestamp: 1719792000 }));
+  t.context.client.scheduleNewsletter(8);
+  t.true(post.calledWith(`${API}/newsletters/8/schedule`, {}));
+});

--- a/test/api.ts
+++ b/test/api.ts
@@ -1545,3 +1545,103 @@ test('#scheduleNewsletter: posts schedule settings and validates', (t) => {
   t.context.client.scheduleNewsletter(8);
   t.true(post.calledWith(`${API}/newsletters/8/schedule`, {}));
 });
+
+// --- Batch 7: Newsletters — localization & test groups (CDP-6271) ---
+
+test('#createNewsletterLanguage: posts the body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterLanguage(''), { message: 'newsletterId is required' });
+  const variation = { language: 'fr', subject: 'Bonjour', body: '<p>Bonjour</p>' };
+  t.context.client.createNewsletterLanguage(8, variation);
+  t.true(post.calledWith(`${API}/newsletters/8/language`, variation));
+  t.context.client.createNewsletterLanguage(8);
+  t.true(post.calledWith(`${API}/newsletters/8/language`, {}));
+});
+
+test('#getNewsletterLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterLanguage('', 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterLanguage(8, ''), { message: 'language is required' });
+  t.context.client.getNewsletterLanguage(8, 'en-US');
+  t.true(get.calledWith(`${API}/newsletters/8/language/en-US`));
+});
+
+test('#updateNewsletterLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateNewsletterLanguage('', 'en', {}), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.updateNewsletterLanguage(8, '', {}), { message: 'language is required' });
+  t.context.client.updateNewsletterLanguage(8, 'fr', { subject: 'Salut' });
+  t.true(put.calledWith(`${API}/newsletters/8/language/fr`, { subject: 'Salut' }));
+  t.context.client.updateNewsletterLanguage(8, 'fr');
+  t.true(put.calledWith(`${API}/newsletters/8/language/fr`, {}));
+});
+
+test('#deleteNewsletterLanguage: deletes a translation and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteNewsletterLanguage('', 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.deleteNewsletterLanguage(8, ''), { message: 'language is required' });
+  t.context.client.deleteNewsletterLanguage(8, 'fr');
+  t.true(destroy.calledWith(`${API}/newsletters/8/language/fr`));
+});
+
+test('#getNewsletterTestGroups: lists test groups and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterTestGroups(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterTestGroups(8);
+  t.true(get.calledWith(`${API}/newsletters/8/test_groups`));
+});
+
+test('#createNewsletterTestGroup: posts to test_groups (no body) and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterTestGroup(''), { message: 'newsletterId is required' });
+  t.context.client.createNewsletterTestGroup(8);
+  t.true(post.calledWith(`${API}/newsletters/8/test_groups`));
+});
+
+test('#createNewsletterTestGroupLanguage: posts to test_group/{id}/language and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterTestGroupLanguage('', 2), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.createNewsletterTestGroupLanguage(8, ''), { message: 'testGroupId is required' });
+  const variation = { language: 'fr', subject: 'Bonjour', body: '<p>Bonjour</p>' };
+  t.context.client.createNewsletterTestGroupLanguage(8, 2, variation);
+  t.true(post.calledWith(`${API}/newsletters/8/test_group/2/language`, variation));
+  t.context.client.createNewsletterTestGroupLanguage(8, 2);
+  t.true(post.calledWith(`${API}/newsletters/8/test_group/2/language`, {}));
+});
+
+test('#getNewsletterTestGroupLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage('', 2, 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage(8, '', 'en'), { message: 'testGroupId is required' });
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage(8, 2, ''), { message: 'language is required' });
+  t.context.client.getNewsletterTestGroupLanguage(8, 2, 'en-US');
+  t.true(get.calledWith(`${API}/newsletters/8/test_group/2/language/en-US`));
+});
+
+test('#updateNewsletterTestGroupLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage('', 2, 'en', {}), {
+    message: 'newsletterId is required',
+  });
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage(8, '', 'en', {}), {
+    message: 'testGroupId is required',
+  });
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage(8, 2, '', {}), { message: 'language is required' });
+  t.context.client.updateNewsletterTestGroupLanguage(8, 2, 'fr', { subject: 'Salut' });
+  t.true(put.calledWith(`${API}/newsletters/8/test_group/2/language/fr`, { subject: 'Salut' }));
+  t.context.client.updateNewsletterTestGroupLanguage(8, 2, 'fr');
+  t.true(put.calledWith(`${API}/newsletters/8/test_group/2/language/fr`, {}));
+});
+
+test('#deleteNewsletterTestGroupLanguage: deletes a translation and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage('', 2, 'en'), {
+    message: 'newsletterId is required',
+  });
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage(8, '', 'en'), {
+    message: 'testGroupId is required',
+  });
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage(8, 2, ''), { message: 'language is required' });
+  t.context.client.deleteNewsletterTestGroupLanguage(8, 2, 'fr');
+  t.true(destroy.calledWith(`${API}/newsletters/8/test_group/2/language/fr`));
+});

--- a/test/api.ts
+++ b/test/api.ts
@@ -1437,8 +1437,9 @@ test('#listNewsletters: forwards pagination + sort', (t) => {
 
 test('#createNewsletter: posts the body', (t) => {
   const post = sinon.stub(t.context.client.request, 'post');
-  t.context.client.createNewsletter({ name: 'Weekly' });
-  t.true(post.calledWith(`${API}/newsletters`, { name: 'Weekly' }));
+  const newsletter = { name: 'Weekly', recipients: { segment: { id: 7 } } };
+  t.context.client.createNewsletter(newsletter);
+  t.true(post.calledWith(`${API}/newsletters`, newsletter));
   t.context.client.createNewsletter();
   t.true(post.calledWith(`${API}/newsletters`, {}));
 });
@@ -1486,23 +1487,23 @@ test('#getNewsletterContentMetrics: forwards options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getNewsletterContentMetrics('', 3), { message: 'newsletterId is required' });
   t.throws(() => t.context.client.getNewsletterContentMetrics(8, ''), { message: 'contentId is required' });
-  t.context.client.getNewsletterContentMetrics(8, 3, { period: 'days', steps: 7, type: 'inbox' });
-  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics?period=days&steps=7&type=inbox`));
+  t.context.client.getNewsletterContentMetrics(8, 3, { period: 'days', steps: 7 });
+  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics?period=days&steps=7`));
 });
 
 test('#getNewsletterContentMetricsLinks: forwards options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getNewsletterContentMetricsLinks('', 3), { message: 'newsletterId is required' });
   t.throws(() => t.context.client.getNewsletterContentMetricsLinks(8, ''), { message: 'contentId is required' });
-  t.context.client.getNewsletterContentMetricsLinks(8, 3, { period: 'weeks', steps: 4, type: 'email' });
-  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics/links?period=weeks&steps=4&type=email`));
+  t.context.client.getNewsletterContentMetricsLinks(8, 3, { period: 'weeks', steps: 4, unique: true });
+  t.true(get.calledWith(`${API}/newsletters/8/contents/3/metrics/links?period=weeks&steps=4&unique=true`));
 });
 
 test('#getNewsletterMetrics: forwards options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getNewsletterMetrics(''), { message: 'newsletterId is required' });
-  t.context.client.getNewsletterMetrics(8, { period: 'days', steps: 30, type: 'email' });
-  t.true(get.calledWith(`${API}/newsletters/8/metrics?period=days&steps=30&type=email`));
+  t.context.client.getNewsletterMetrics(8, { period: 'days', steps: 30 });
+  t.true(get.calledWith(`${API}/newsletters/8/metrics?period=days&steps=30`));
 });
 
 test('#getNewsletterMetricsLinks: forwards unique and validates', (t) => {
@@ -1515,8 +1516,15 @@ test('#getNewsletterMetricsLinks: forwards unique and validates', (t) => {
 test('#getNewsletterMessages: forwards filters and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getNewsletterMessages(''), { message: 'newsletterId is required' });
-  t.context.client.getNewsletterMessages(8, { metric: 'delivered', limit: 50, get_tracked_responses: true });
-  t.true(get.calledWith(`${API}/newsletters/8/messages?limit=50&metric=delivered&get_tracked_responses=true`));
+  t.context.client.getNewsletterMessages(8, {
+    metric: 'delivered',
+    type: 'email',
+    limit: 50,
+    get_tracked_responses: true,
+  });
+  t.true(
+    get.calledWith(`${API}/newsletters/8/messages?limit=50&metric=delivered&type=email&get_tracked_responses=true`),
+  );
 });
 
 test('#sendNewsletter: posts send settings and validates', (t) => {
@@ -1531,8 +1539,9 @@ test('#sendNewsletter: posts send settings and validates', (t) => {
 test('#scheduleNewsletter: posts schedule settings and validates', (t) => {
   const post = sinon.stub(t.context.client.request, 'post');
   t.throws(() => t.context.client.scheduleNewsletter(''), { message: 'newsletterId is required' });
-  t.context.client.scheduleNewsletter(8, { timestamp: 1719792000 });
-  t.true(post.calledWith(`${API}/newsletters/8/schedule`, { timestamp: 1719792000 }));
+  const schedule = { scheduled_at: 1719792000, timezone: 'America/New_York' };
+  t.context.client.scheduleNewsletter(8, schedule);
+  t.true(post.calledWith(`${API}/newsletters/8/schedule`, schedule));
   t.context.client.scheduleNewsletter(8);
   t.true(post.calledWith(`${API}/newsletters/8/schedule`, {}));
 });

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -273,6 +273,24 @@ needs('CIO_TEST_BROADCAST_ID')('broadcast reads resolve for a known id', async (
   t.pass();
 });
 
+liveTest('listNewsletters resolves', async (t) => {
+  const result = (await api!.listNewsletters({ limit: 5 })) as Record<string, unknown>;
+  t.true('newsletters' in result);
+});
+
+// Read-only newsletter lookups for a known id. Create/update/send/schedule are
+// covered by unit tests only (send/schedule actually dispatch; create/delete
+// mutate the workspace).
+needs('CIO_TEST_NEWSLETTER_ID')('newsletter reads resolve for a known id', async (t) => {
+  const id = process.env.CIO_TEST_NEWSLETTER_ID!;
+  await api!.getNewsletter(id).catch(() => undefined);
+  await api!.getNewsletterContents(id).catch(() => undefined);
+  await api!.getNewsletterMetrics(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getNewsletterMetricsLinks(id, { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getNewsletterMessages(id, { limit: 5 }).catch(() => undefined);
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -291,6 +291,15 @@ needs('CIO_TEST_NEWSLETTER_ID')('newsletter reads resolve for a known id', async
   t.pass();
 });
 
+// Newsletter localization reads. The create/update/delete language + test-group
+// methods mutate the workspace, so they're covered by unit tests only.
+needs('CIO_TEST_NEWSLETTER_ID')('newsletter test-group + language reads resolve', async (t) => {
+  const id = process.env.CIO_TEST_NEWSLETTER_ID!;
+  await api!.getNewsletterTestGroups(id).catch(() => undefined);
+  await api!.getNewsletterLanguage(id, 'en').catch(() => undefined);
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();


### PR DESCRIPTION
A new set of the App API backfill which adds the core newsletter endpoints (CRUD, contents, metrics, send/schedule). Localization + test groups are added in #236 

## New methods (14)

`listNewsletters`, `createNewsletter`, `getNewsletter`, `deleteNewsletter`, `getNewsletterContents`, `getNewsletterContent`, `updateNewsletterContent`, `getNewsletterContentMetrics`, `getNewsletterContentMetricsLinks`, `getNewsletterMetrics`, `getNewsletterMetricsLinks`, `getNewsletterMessages`, `sendNewsletter`, `scheduleNewsletter`.

Assisted by AI 🤖 



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds `sendNewsletter` and `scheduleNewsletter`, which can trigger real customer messaging; otherwise additive SDK wrappers with validation consistent with existing broadcast methods.
> 
> **Overview**
> Extends **`APIClient`** with Customer.io App API **newsletter** support, reusing the existing campaign/broadcast pattern via an updated **`resourceBase('newsletters', …)`** helper.
> 
> **Core surface:** list/create/get/delete newsletters; content variants (list/get/update); newsletter- and content-level **metrics** and **link metrics**; **messages** listing with channel filters; **`sendNewsletter`** and **`scheduleNewsletter`**.
> 
> **Also in this diff:** language CRUD on newsletters and on **test groups** (list/create test groups plus per-group language endpoints). New option types include **`ListNewslettersOptions`**, **`NewsletterMetricsOptions`** (no per-channel `type` on metrics), **`NewsletterChannelType`**, and **`NewsletterMessagesOptions`**.
> 
> **Docs** in `docs/app.md` document every new method. **Tests** stub HTTP paths and query strings in `test/api.ts`; **`test/integration/live.ts`** adds read-only checks for `listNewsletters` and optional `CIO_TEST_NEWSLETTER_ID` lookups (mutating/send paths stay unit-tested only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edf85ee29bedca0c2b44d1bb9d5b5e7ba927aae2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->