### PR TITLE
Add App API newsletter localization & test-group methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -1158,3 +1158,139 @@ api.scheduleNewsletter(8, { scheduled_at: 1719792000, timezone: "America/New_Yor
   - _scheduled_at_: Unix timestamp (seconds) when the newsletter should send (required, must be in the future)
   - _timezone_: IANA timezone the scheduled time is expressed in (required)
   - Optional: `tz_match_enabled`, `rate_limit_email_rate`, `rate_limit_time_period`, `rate_limit_spread`
+
+### api.createNewsletterLanguage(newsletterId, data)
+
+Add a language (translation) to a newsletter. `language` is required, and the required content fields depend on the newsletter's channel (e.g. an email newsletter requires `subject` and `body`).
+
+```javascript
+api.createNewsletterLanguage(8, { language: "fr", subject: "Bonjour", body: "<p>Bonjour&nbsp;!</p>" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **data**: The translation content
+  - _language_: The IETF language tag (required)
+  - _subject_ / _body_: Required for email; other channels require their own fields (e.g. `body_json` for in-app/inbox, `body` for SMS/webhook)
+
+### api.getNewsletterLanguage(newsletterId, language)
+
+Get a single-language translation of a newsletter.
+
+```javascript
+api.getNewsletterLanguage(8, "en-US");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateNewsletterLanguage(newsletterId, language, data)
+
+Update a single-language translation of a newsletter.
+
+```javascript
+api.updateNewsletterLanguage(8, "fr", { subject: "Salut" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.deleteNewsletterLanguage(newsletterId, language)
+
+Delete a single-language translation of a newsletter.
+
+```javascript
+api.deleteNewsletterLanguage(8, "fr");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **language**: The IETF language tag (required)
+
+### api.getNewsletterTestGroups(newsletterId)
+
+List a newsletter's A/B test groups.
+
+```javascript
+api.getNewsletterTestGroups(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.createNewsletterTestGroup(newsletterId)
+
+Create an A/B test group on a newsletter. The API takes no request body — a new empty test group is created.
+
+```javascript
+api.createNewsletterTestGroup(8);
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+
+### api.createNewsletterTestGroupLanguage(newsletterId, testGroupId, data)
+
+Add a language (translation) to a newsletter test group. Same content requirements as `createNewsletterLanguage` (`language` required, plus channel-specific fields such as `subject`/`body` for email).
+
+```javascript
+api.createNewsletterTestGroupLanguage(8, 2, { language: "fr", subject: "Bonjour", body: "<p>Bonjour&nbsp;!</p>" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **data**: The translation content (`language` required; channel-specific content fields required)
+
+### api.getNewsletterTestGroupLanguage(newsletterId, testGroupId, language)
+
+Get a single-language translation of a newsletter test group.
+
+```javascript
+api.getNewsletterTestGroupLanguage(8, 2, "en-US");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)
+
+### api.updateNewsletterTestGroupLanguage(newsletterId, testGroupId, language, data)
+
+Update a single-language translation of a newsletter test group.
+
+```javascript
+api.updateNewsletterTestGroupLanguage(8, 2, "fr", { subject: "Salut" });
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)
+- **data**: The translation fields to update
+
+### api.deleteNewsletterTestGroupLanguage(newsletterId, testGroupId, language)
+
+Delete a single-language translation of a newsletter test group.
+
+```javascript
+api.deleteNewsletterTestGroupLanguage(8, 2, "fr");
+```
+
+#### Options
+
+- **newsletterId**: The newsletter's numeric id (required)
+- **testGroupId**: The test group's id (required)
+- **language**: The IETF language tag (required)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -2101,6 +2101,237 @@ export class APIClient {
 
     return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/schedule`, data);
   }
+
+  /**
+   * Add a language (translation) to a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param data The translation content, including its `language` tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  createNewsletterLanguage(newsletterId: string | number, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/language`, data);
+  }
+
+  /**
+   * Get a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  getNewsletterLanguage(newsletterId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  updateNewsletterLanguage(newsletterId: string | number, language: string, data: RequestData = {}) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Delete a single-language translation of a newsletter.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `language` is empty.
+   */
+  deleteNewsletterLanguage(newsletterId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.destroy(
+      `${this.resourceBase('newsletters', newsletterId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * List a newsletter's A/B test groups.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  getNewsletterTestGroups(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.get(`${this.resourceBase('newsletters', newsletterId)}/test_groups`);
+  }
+
+  /**
+   * Create an A/B test group on a newsletter. The API takes no request body —
+   * a new empty test group is created and returned.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @returns The parsed JSON response body (the updated newsletter).
+   * @throws {MissingParamError} If `newsletterId` is empty.
+   */
+  createNewsletterTestGroup(newsletterId: string | number) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    return this.request.post(`${this.resourceBase('newsletters', newsletterId)}/test_groups`);
+  }
+
+  /**
+   * Add a language (translation) to a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param data The translation content, including its `language` tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId` or `testGroupId` is empty.
+   */
+  createNewsletterTestGroupLanguage(
+    newsletterId: string | number,
+    testGroupId: string | number,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    return this.request.post(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language`,
+      data,
+    );
+  }
+
+  /**
+   * Get a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  getNewsletterTestGroupLanguage(newsletterId: string | number, testGroupId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @param data The translation fields to update.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  updateNewsletterTestGroupLanguage(
+    newsletterId: string | number,
+    testGroupId: string | number,
+    language: string,
+    data: RequestData = {},
+  ) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.put(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+      data,
+    );
+  }
+
+  /**
+   * Delete a single-language translation of a newsletter test group.
+   *
+   * @param newsletterId The newsletter's numeric id.
+   * @param testGroupId The test group's id.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `newsletterId`, `testGroupId`, or `language` is empty.
+   */
+  deleteNewsletterTestGroupLanguage(newsletterId: string | number, testGroupId: string | number, language: string) {
+    if (isEmpty(newsletterId)) {
+      throw new MissingParamError('newsletterId');
+    }
+
+    if (isEmpty(testGroupId)) {
+      throw new MissingParamError('testGroupId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.destroy(
+      `${this.resourceBase('newsletters', newsletterId)}/test_group/${encodeURIComponent(testGroupId)}/language/${encodeURIComponent(language)}`,
+    );
+  }
 }
 
 export {

--- a/test/api.ts
+++ b/test/api.ts
@@ -1545,3 +1545,103 @@ test('#scheduleNewsletter: posts schedule settings and validates', (t) => {
   t.context.client.scheduleNewsletter(8);
   t.true(post.calledWith(`${API}/newsletters/8/schedule`, {}));
 });
+
+// --- Batch 7: Newsletters — localization & test groups (CDP-6271) ---
+
+test('#createNewsletterLanguage: posts the body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterLanguage(''), { message: 'newsletterId is required' });
+  const variation = { language: 'fr', subject: 'Bonjour', body: '<p>Bonjour</p>' };
+  t.context.client.createNewsletterLanguage(8, variation);
+  t.true(post.calledWith(`${API}/newsletters/8/language`, variation));
+  t.context.client.createNewsletterLanguage(8);
+  t.true(post.calledWith(`${API}/newsletters/8/language`, {}));
+});
+
+test('#getNewsletterLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterLanguage('', 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterLanguage(8, ''), { message: 'language is required' });
+  t.context.client.getNewsletterLanguage(8, 'en-US');
+  t.true(get.calledWith(`${API}/newsletters/8/language/en-US`));
+});
+
+test('#updateNewsletterLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateNewsletterLanguage('', 'en', {}), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.updateNewsletterLanguage(8, '', {}), { message: 'language is required' });
+  t.context.client.updateNewsletterLanguage(8, 'fr', { subject: 'Salut' });
+  t.true(put.calledWith(`${API}/newsletters/8/language/fr`, { subject: 'Salut' }));
+  t.context.client.updateNewsletterLanguage(8, 'fr');
+  t.true(put.calledWith(`${API}/newsletters/8/language/fr`, {}));
+});
+
+test('#deleteNewsletterLanguage: deletes a translation and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteNewsletterLanguage('', 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.deleteNewsletterLanguage(8, ''), { message: 'language is required' });
+  t.context.client.deleteNewsletterLanguage(8, 'fr');
+  t.true(destroy.calledWith(`${API}/newsletters/8/language/fr`));
+});
+
+test('#getNewsletterTestGroups: lists test groups and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterTestGroups(''), { message: 'newsletterId is required' });
+  t.context.client.getNewsletterTestGroups(8);
+  t.true(get.calledWith(`${API}/newsletters/8/test_groups`));
+});
+
+test('#createNewsletterTestGroup: posts to test_groups (no body) and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterTestGroup(''), { message: 'newsletterId is required' });
+  t.context.client.createNewsletterTestGroup(8);
+  t.true(post.calledWith(`${API}/newsletters/8/test_groups`));
+});
+
+test('#createNewsletterTestGroupLanguage: posts to test_group/{id}/language and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => t.context.client.createNewsletterTestGroupLanguage('', 2), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.createNewsletterTestGroupLanguage(8, ''), { message: 'testGroupId is required' });
+  const variation = { language: 'fr', subject: 'Bonjour', body: '<p>Bonjour</p>' };
+  t.context.client.createNewsletterTestGroupLanguage(8, 2, variation);
+  t.true(post.calledWith(`${API}/newsletters/8/test_group/2/language`, variation));
+  t.context.client.createNewsletterTestGroupLanguage(8, 2);
+  t.true(post.calledWith(`${API}/newsletters/8/test_group/2/language`, {}));
+});
+
+test('#getNewsletterTestGroupLanguage: gets a translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage('', 2, 'en'), { message: 'newsletterId is required' });
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage(8, '', 'en'), { message: 'testGroupId is required' });
+  t.throws(() => t.context.client.getNewsletterTestGroupLanguage(8, 2, ''), { message: 'language is required' });
+  t.context.client.getNewsletterTestGroupLanguage(8, 2, 'en-US');
+  t.true(get.calledWith(`${API}/newsletters/8/test_group/2/language/en-US`));
+});
+
+test('#updateNewsletterTestGroupLanguage: puts the translation and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage('', 2, 'en', {}), {
+    message: 'newsletterId is required',
+  });
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage(8, '', 'en', {}), {
+    message: 'testGroupId is required',
+  });
+  t.throws(() => t.context.client.updateNewsletterTestGroupLanguage(8, 2, '', {}), { message: 'language is required' });
+  t.context.client.updateNewsletterTestGroupLanguage(8, 2, 'fr', { subject: 'Salut' });
+  t.true(put.calledWith(`${API}/newsletters/8/test_group/2/language/fr`, { subject: 'Salut' }));
+  t.context.client.updateNewsletterTestGroupLanguage(8, 2, 'fr');
+  t.true(put.calledWith(`${API}/newsletters/8/test_group/2/language/fr`, {}));
+});
+
+test('#deleteNewsletterTestGroupLanguage: deletes a translation and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage('', 2, 'en'), {
+    message: 'newsletterId is required',
+  });
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage(8, '', 'en'), {
+    message: 'testGroupId is required',
+  });
+  t.throws(() => t.context.client.deleteNewsletterTestGroupLanguage(8, 2, ''), { message: 'language is required' });
+  t.context.client.deleteNewsletterTestGroupLanguage(8, 2, 'fr');
+  t.true(destroy.calledWith(`${API}/newsletters/8/test_group/2/language/fr`));
+});

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -291,6 +291,15 @@ needs('CIO_TEST_NEWSLETTER_ID')('newsletter reads resolve for a known id', async
   t.pass();
 });
 
+// Newsletter localization reads. The create/update/delete language + test-group
+// methods mutate the workspace, so they're covered by unit tests only.
+needs('CIO_TEST_NEWSLETTER_ID')('newsletter test-group + language reads resolve', async (t) => {
+  const id = process.env.CIO_TEST_NEWSLETTER_ID!;
+  await api!.getNewsletterTestGroups(id).catch(() => undefined);
+  await api!.getNewsletterLanguage(id, 'en').catch(() => undefined);
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();


### PR DESCRIPTION
This is the remaining set of the newsletter App API backfill which adds newsletter localization (per-language content) and A/B test groups. Follows #235.

## New methods (10)

`createNewsletterLanguage`, `getNewsletterLanguage`, `updateNewsletterLanguage`, `deleteNewsletterLanguage`, `getNewsletterTestGroups`, `createNewsletterTestGroup`, `createNewsletterTestGroupLanguage`, `getNewsletterTestGroupLanguage`, `updateNewsletterTestGroupLanguage`, `deleteNewsletterTestGroupLanguage`.

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive SDK surface and documentation with thorough unit tests; no changes to auth, sends, or existing method behavior.
> 
> **Overview**
> Adds **10** `APIClient` methods for newsletter **per-language content** and **A/B test groups**, completing the newsletter App API backfill.
> 
> **Newsletter translations:** `createNewsletterLanguage`, `getNewsletterLanguage`, `updateNewsletterLanguage`, and `deleteNewsletterLanguage` call `/newsletters/{id}/language` (with `encodeURIComponent` on language tags).
> 
> **Test groups:** `getNewsletterTestGroups` and `createNewsletterTestGroup` use `/test_groups`; test-group languages mirror the newsletter CRUD under `/test_group/{testGroupId}/language`. Methods validate `newsletterId`, `testGroupId`, and `language` with `MissingParamError` where applicable.
> 
> **Docs & tests:** `docs/app.md` documents all methods with examples. Unit tests in `test/api.ts` (Batch 7, CDP-6271) assert URLs and validation. Live tests only exercise read paths (`getNewsletterTestGroups`, `getNewsletterLanguage`); mutating calls stay unit-tested only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6969d26040838a7ab0a64fb8bc4caecb0c792df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->