### PR TITLE
Align App API metric/message methods with backend from audit

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -486,7 +486,7 @@ api.getTransactionalMessageDeliveries(3, { metric: "delivered", limit: 50 });
 #### Options
 
 - **transactionalId**: The transactional message's numeric id (required)
-- **options**: Object (optional) — `start`, `limit`, `metric`, `state`, `start_ts`, `end_ts`, `get_tracked_responses`
+- **options**: Object (optional) — `start`, `limit`, `metric`, `start_ts`, `end_ts`, `get_tracked_responses`
 
 ### api.getTransactionalMessageMetrics(transactionalId, options)
 
@@ -694,48 +694,46 @@ api.updateCampaignActionLanguage(9, 2, "fr", { subject: "Bonjour" });
 - **language**: The IETF language tag (required)
 - **data**: The translation fields to update
 
-### api.getCampaignActionMetrics(campaignId, actionId, version, options)
+### api.getCampaignActionMetrics(campaignId, actionId, options)
 
-Get metrics for a single campaign action over time.
+Get metrics for a single campaign action over time. Aggregated across all channels (no `type` filter).
 
 ```javascript
-api.getCampaignActionMetrics(9, 2, "2", { type: "email", period: "days", steps: 7 });
+api.getCampaignActionMetrics(9, 2, { version: "2", period: "days", steps: 7 });
 ```
 
 #### Options
 
 - **campaignId**: The campaign's numeric id (required)
 - **actionId**: The action's numeric id (required)
-- **version**: Metrics API version — "1" or "2" (required)
-- **options**: Object (optional) — `type`, `res`, `tz`, `start`, `end`, `period`, `steps`
+- **options**: Object (optional) — `version` ("1" / "2"), `res`, `tz`, `start`, `end`, `period`, `steps`
 
 ### api.getCampaignActionMetricsLinks(campaignId, actionId, options)
 
 Get link (click) metrics for a single campaign action over time.
 
 ```javascript
-api.getCampaignActionMetricsLinks(9, 2, { period: "weeks", steps: 4, type: "email" });
+api.getCampaignActionMetricsLinks(9, 2, { period: "weeks", steps: 4, unique: true });
 ```
 
 #### Options
 
 - **campaignId**: The campaign's numeric id (required)
 - **actionId**: The action's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type`
+- **options**: Object (optional) — `period`, `steps`, `unique`
 
-### api.getCampaignMetrics(campaignId, version, options)
+### api.getCampaignMetrics(campaignId, options)
 
 Get delivery metrics for a campaign over time.
 
 ```javascript
-api.getCampaignMetrics(9, "1", { res: "daily", start: 1719792000, end: 1719878400 });
+api.getCampaignMetrics(9, { version: "1", res: "daily", start: 1719792000, end: 1719878400 });
 ```
 
 #### Options
 
 - **campaignId**: The campaign's numeric id (required)
-- **version**: Metrics API version — "1" or "2" (required)
-- **options**: Object (optional) — `type`, `res`, `tz`, `start`, `end`, `period`, `steps`
+- **options**: Object (optional) — `version` ("1" / "2"), `type`, `res`, `tz`, `start`, `end`, `period`, `steps`
 
 ### api.getCampaignMetricsLinks(campaignId, options)
 
@@ -893,31 +891,31 @@ api.updateBroadcastActionLanguage(4, 2, "fr", { subject: "Bonjour" });
 
 ### api.getBroadcastActionMetrics(broadcastId, actionId, options)
 
-Get metrics for a single broadcast action over time.
+Get metrics for a single broadcast action over time. Aggregated across all channels (no `type` filter).
 
 ```javascript
-api.getBroadcastActionMetrics(4, 2, { period: "days", steps: 7, type: "email" });
+api.getBroadcastActionMetrics(4, 2, { period: "days", steps: 7 });
 ```
 
 #### Options
 
 - **broadcastId**: The broadcast's numeric id (required)
 - **actionId**: The action's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type`
+- **options**: Object (optional) — `period`, `steps`
 
 ### api.getBroadcastActionMetricsLinks(broadcastId, actionId, options)
 
 Get link (click) metrics for a single broadcast action over time.
 
 ```javascript
-api.getBroadcastActionMetricsLinks(4, 2, { period: "weeks", steps: 4, type: "email" });
+api.getBroadcastActionMetricsLinks(4, 2, { period: "weeks", steps: 4, unique: true });
 ```
 
 #### Options
 
 - **broadcastId**: The broadcast's numeric id (required)
 - **actionId**: The action's numeric id (required)
-- **options**: Object (optional) — `period`, `steps`, `type`
+- **options**: Object (optional) — `period`, `steps`, `unique`
 
 ### api.getBroadcastMetrics(broadcastId, options)
 
@@ -950,13 +948,13 @@ api.getBroadcastMetricsLinks(4, { period: "days", steps: 30, unique: true });
 Get the individual messages (deliveries) sent by a broadcast.
 
 ```javascript
-api.getBroadcastMessages(4, { metric: "delivered", state: "sent", limit: 50 });
+api.getBroadcastMessages(4, { metric: "delivered", type: "email", limit: 50 });
 ```
 
 #### Options
 
 - **broadcastId**: The broadcast's numeric id (required)
-- **options**: Object (optional) — `start`, `limit`, `metric`, `state`, `type`, `start_ts`, `end_ts`, `get_tracked_responses`
+- **options**: Object (optional) — `start`, `limit`, `metric`, `type`, `start_ts`, `end_ts`, `get_tracked_responses`
 
 ### api.getBroadcastTriggers(broadcastId)
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -98,8 +98,6 @@ export type TransactionalLinkMetricsOptions = TransactionalMetricsOptions & {
 export type TransactionalDeliveriesOptions = PaginationOptions & {
   /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
   metric?: string;
-  /** Filter to deliveries in this state. */
-  state?: DeliveryState;
   /** Only include deliveries after this Unix timestamp (seconds). */
   start_ts?: number;
   /** Only include deliveries before this Unix timestamp (seconds). */
@@ -114,32 +112,33 @@ export type MetricType = 'email' | 'webhook' | 'twilio' | 'whatsapp' | 'slack' |
 /** Resolution (bucket size) for time-series metric reports. */
 export type MetricResolution = 'hours' | 'hourly' | 'days' | 'daily' | 'weeks' | 'weekly' | 'months' | 'monthly';
 
-/** Delivery state a message/delivery listing can be filtered by. */
-export type DeliveryState = 'failed' | 'sent' | 'drafted' | 'attempted';
-
 /** Metrics API version for campaign metric reports. */
 export type CampaignMetricsVersion = '1' | '2';
 
-/** Options for channel-scoped metric reports (broadcast metrics, action metrics/links). */
-export type MetricsOptions = {
+/** Reporting window shared by all metric reports. */
+export type MetricsWindowOptions = {
   /** The time unit each step represents. */
   period?: MetricsPeriod;
   /** The number of periods to report over. */
   steps?: number;
+};
+
+/** Options for channel-scoped metric reports (e.g. broadcast/campaign resource metrics). */
+export type MetricsOptions = MetricsWindowOptions & {
   /** Scope the report to a single channel. */
   type?: MetricType;
 };
 
-/** Options for resource-level link (click) metric reports. */
-export type LinkMetricsOptions = {
-  period?: MetricsPeriod;
-  steps?: number;
+/** Options for link (click) metric reports. */
+export type LinkMetricsOptions = MetricsWindowOptions & {
   /** When `true`, count unique clicks per link rather than total clicks. */
   unique?: boolean;
 };
 
-/** Options for campaign metric reports. Pass the required `version` separately. */
-export type CampaignMetricsOptions = {
+/** Options for campaign resource metric reports. */
+export type CampaignMetricsOptions = MetricsWindowOptions & {
+  /** Metrics API version (`"1"` or `"2"`). Optional; the API defaults it. */
+  version?: CampaignMetricsVersion;
   /** Scope the report to a single channel. */
   type?: MetricType;
   /** Resolution (bucket size) of the report. */
@@ -150,8 +149,23 @@ export type CampaignMetricsOptions = {
   start?: number;
   /** Inclusive end of the window, as a Unix timestamp (seconds). */
   end?: number;
-  period?: MetricsPeriod;
-  steps?: number;
+};
+
+/**
+ * Options for campaign action metric reports. Like {@link CampaignMetricsOptions}
+ * but without `type` — action metrics are always aggregated across all channels.
+ */
+export type CampaignActionMetricsOptions = MetricsWindowOptions & {
+  /** Metrics API version (`"1"` or `"2"`). Optional; the API defaults it. */
+  version?: CampaignMetricsVersion;
+  /** Resolution (bucket size) of the report. */
+  res?: MetricResolution;
+  /** IANA timezone for bucket boundaries (e.g. `America/New_York`). */
+  tz?: string;
+  /** Inclusive start of the window, as a Unix timestamp (seconds). */
+  start?: number;
+  /** Inclusive end of the window, as a Unix timestamp (seconds). */
+  end?: number;
 };
 
 /** Required options for {@link APIClient.getCampaignJourneyMetrics}. */
@@ -184,8 +198,6 @@ export type CampaignMessagesOptions = PaginationOptions & {
 export type BroadcastMessagesOptions = PaginationOptions & {
   /** Filter to deliveries with this metric (e.g. `delivered`, `opened`, `bounced`). */
   metric?: string;
-  /** Filter to deliveries in this state. */
-  state?: DeliveryState;
   /** Scope to a single channel. */
   type?: MetricType;
   /** Only include deliveries after this Unix timestamp (seconds). */
@@ -512,7 +524,7 @@ export class APIClient {
    * Only meaningful once {@link APIClient.getExport} reports the export as ready.
    *
    * @param id The export id.
-   * @returns The parsed JSON response body (`{ link: "..." }`).
+   * @returns The parsed JSON response body (`{ url: "..." }`).
    * @throws {MissingParamError} If `id` is empty.
    */
   downloadExport(id: string | number) {
@@ -1097,7 +1109,6 @@ export class APIClient {
       start: options.start,
       limit: options.limit,
       metric: options.metric,
-      state: options.state,
       start_ts: options.start_ts,
       end_ts: options.end_ts,
       get_tracked_responses: options.get_tracked_responses,
@@ -1328,20 +1339,19 @@ export class APIClient {
   }
 
   /**
-   * Get metrics for a single campaign action over time.
+   * Get metrics for a single campaign action over time. Aggregated across all
+   * channels (the API does not accept a `type` filter here).
    *
    * @param campaignId The campaign's numeric id.
    * @param actionId The action's numeric id.
-   * @param version The metrics API version (`"1"` or `"2"`) — required by the API.
-   * @param options Optional reporting window/filters. See {@link CampaignMetricsOptions}.
+   * @param options Optional reporting window/version. See {@link CampaignActionMetricsOptions}.
    * @returns The parsed JSON response body.
-   * @throws {MissingParamError} If `campaignId`, `actionId`, or `version` is empty.
+   * @throws {MissingParamError} If `campaignId` or `actionId` is empty.
    */
   getCampaignActionMetrics(
     campaignId: string | number,
     actionId: string | number,
-    version: CampaignMetricsVersion,
-    options: CampaignMetricsOptions = {},
+    options: CampaignActionMetricsOptions = {},
   ) {
     if (isEmpty(campaignId)) {
       throw new MissingParamError('campaignId');
@@ -1351,13 +1361,8 @@ export class APIClient {
       throw new MissingParamError('actionId');
     }
 
-    if (isEmpty(version)) {
-      throw new MissingParamError('version');
-    }
-
     const query = buildQueryString({
-      version,
-      type: options.type,
+      version: options.version,
       res: options.res,
       tz: options.tz,
       start: options.start,
@@ -1376,11 +1381,15 @@ export class APIClient {
    *
    * @param campaignId The campaign's numeric id.
    * @param actionId The action's numeric id.
-   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `campaignId` or `actionId` is empty.
    */
-  getCampaignActionMetricsLinks(campaignId: string | number, actionId: string | number, options: MetricsOptions = {}) {
+  getCampaignActionMetricsLinks(
+    campaignId: string | number,
+    actionId: string | number,
+    options: LinkMetricsOptions = {},
+  ) {
     if (isEmpty(campaignId)) {
       throw new MissingParamError('campaignId');
     }
@@ -1389,7 +1398,7 @@ export class APIClient {
       throw new MissingParamError('actionId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
 
     return this.request.get(
       `${this.resourceBase('campaigns', campaignId)}/actions/${encodeURIComponent(actionId)}/metrics/links${query}`,
@@ -1400,26 +1409,17 @@ export class APIClient {
    * Get delivery metrics for a campaign over time.
    *
    * @param campaignId The campaign's numeric id.
-   * @param version The metrics API version (`"1"` or `"2"`) — required by the API.
    * @param options Optional reporting window/filters. See {@link CampaignMetricsOptions}.
    * @returns The parsed JSON response body.
-   * @throws {MissingParamError} If `campaignId` or `version` is empty.
+   * @throws {MissingParamError} If `campaignId` is empty.
    */
-  getCampaignMetrics(
-    campaignId: string | number,
-    version: CampaignMetricsVersion,
-    options: CampaignMetricsOptions = {},
-  ) {
+  getCampaignMetrics(campaignId: string | number, options: CampaignMetricsOptions = {}) {
     if (isEmpty(campaignId)) {
       throw new MissingParamError('campaignId');
     }
 
-    if (isEmpty(version)) {
-      throw new MissingParamError('version');
-    }
-
     const query = buildQueryString({
-      version,
+      version: options.version,
       type: options.type,
       res: options.res,
       tz: options.tz,
@@ -1475,7 +1475,7 @@ export class APIClient {
       throw new MissingParamError('options.res');
     }
 
-    const query = buildQueryString({ start: options.start, end: options.end, res: options.res });
+    const query = buildQueryString({ start: options.start, end: options.end, resolution: options.res });
 
     return this.request.get(`${this.resourceBase('campaigns', campaignId)}/journey_metrics${query}`);
   }
@@ -1699,15 +1699,20 @@ export class APIClient {
   }
 
   /**
-   * Get metrics for a single broadcast action over time.
+   * Get metrics for a single broadcast action over time. Aggregated across all
+   * channels (the API does not accept a `type` filter here).
    *
    * @param broadcastId The broadcast's numeric id.
    * @param actionId The action's numeric id.
-   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @param options Optional reporting window. See {@link MetricsWindowOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
    */
-  getBroadcastActionMetrics(broadcastId: string | number, actionId: string | number, options: MetricsOptions = {}) {
+  getBroadcastActionMetrics(
+    broadcastId: string | number,
+    actionId: string | number,
+    options: MetricsWindowOptions = {},
+  ) {
     if (isEmpty(broadcastId)) {
       throw new MissingParamError('broadcastId');
     }
@@ -1716,7 +1721,7 @@ export class APIClient {
       throw new MissingParamError('actionId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps });
 
     return this.request.get(
       `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/metrics${query}`,
@@ -1728,14 +1733,14 @@ export class APIClient {
    *
    * @param broadcastId The broadcast's numeric id.
    * @param actionId The action's numeric id.
-   * @param options Optional reporting window/filters. See {@link MetricsOptions}.
+   * @param options Optional reporting window. See {@link LinkMetricsOptions}.
    * @returns The parsed JSON response body.
    * @throws {MissingParamError} If `broadcastId` or `actionId` is empty.
    */
   getBroadcastActionMetricsLinks(
     broadcastId: string | number,
     actionId: string | number,
-    options: MetricsOptions = {},
+    options: LinkMetricsOptions = {},
   ) {
     if (isEmpty(broadcastId)) {
       throw new MissingParamError('broadcastId');
@@ -1745,7 +1750,7 @@ export class APIClient {
       throw new MissingParamError('actionId');
     }
 
-    const query = buildQueryString({ period: options.period, steps: options.steps, type: options.type });
+    const query = buildQueryString({ period: options.period, steps: options.steps, unique: options.unique });
 
     return this.request.get(
       `${this.resourceBase('broadcasts', broadcastId)}/actions/${encodeURIComponent(actionId)}/metrics/links${query}`,
@@ -1805,7 +1810,6 @@ export class APIClient {
       start: options.start,
       limit: options.limit,
       metric: options.metric,
-      state: options.state,
       type: options.type,
       start_ts: options.start_ts,
       end_ts: options.end_ts,

--- a/test/api.ts
+++ b/test/api.ts
@@ -1150,7 +1150,6 @@ test('#getTransactionalMessageDeliveries: forwards filters and validates', (t) =
   t.throws(() => t.context.client.getTransactionalMessageDeliveries(''), { message: 'transactionalId is required' });
   t.context.client.getTransactionalMessageDeliveries(3, {
     metric: 'delivered',
-    state: 'sent',
     limit: 50,
     start_ts: 100,
     end_ts: 200,
@@ -1158,7 +1157,7 @@ test('#getTransactionalMessageDeliveries: forwards filters and validates', (t) =
   });
   t.true(
     get.calledWith(
-      `${API}/transactional/3/messages?limit=50&metric=delivered&state=sent&start_ts=100&end_ts=200&get_tracked_responses=true`,
+      `${API}/transactional/3/messages?limit=50&metric=delivered&start_ts=100&end_ts=200&get_tracked_responses=true`,
     ),
   );
 });
@@ -1261,28 +1260,26 @@ test('#updateCampaignActionLanguage: puts the translation and validates', (t) =>
   t.true(put.calledWith(`${API}/campaigns/9/actions/2/language/fr`, {}));
 });
 
-test('#getCampaignActionMetrics: forwards version + options and validates', (t) => {
+test('#getCampaignActionMetrics: forwards version + window (no type) and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
-  t.throws(() => t.context.client.getCampaignActionMetrics('', 2, '1'), { message: 'campaignId is required' });
-  t.throws(() => t.context.client.getCampaignActionMetrics(9, '', '1'), { message: 'actionId is required' });
-  t.throws(() => t.context.client.getCampaignActionMetrics(9, 2, '' as any), { message: 'version is required' });
-  t.context.client.getCampaignActionMetrics(9, 2, '2', { type: 'email', period: 'days', steps: 7 });
-  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics?version=2&type=email&period=days&steps=7`));
+  t.throws(() => t.context.client.getCampaignActionMetrics('', 2), { message: 'campaignId is required' });
+  t.throws(() => t.context.client.getCampaignActionMetrics(9, ''), { message: 'actionId is required' });
+  t.context.client.getCampaignActionMetrics(9, 2, { version: '2', period: 'days', steps: 7 });
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics?version=2&period=days&steps=7`));
 });
 
-test('#getCampaignActionMetricsLinks: forwards type and validates', (t) => {
+test('#getCampaignActionMetricsLinks: forwards unique and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getCampaignActionMetricsLinks('', 2), { message: 'campaignId is required' });
   t.throws(() => t.context.client.getCampaignActionMetricsLinks(9, ''), { message: 'actionId is required' });
-  t.context.client.getCampaignActionMetricsLinks(9, 2, { period: 'weeks', steps: 4, type: 'push' });
-  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics/links?period=weeks&steps=4&type=push`));
+  t.context.client.getCampaignActionMetricsLinks(9, 2, { period: 'weeks', steps: 4, unique: true });
+  t.true(get.calledWith(`${API}/campaigns/9/actions/2/metrics/links?period=weeks&steps=4&unique=true`));
 });
 
 test('#getCampaignMetrics: forwards version + options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
-  t.throws(() => t.context.client.getCampaignMetrics('', '1'), { message: 'campaignId is required' });
-  t.throws(() => t.context.client.getCampaignMetrics(9, '' as any), { message: 'version is required' });
-  t.context.client.getCampaignMetrics(9, '1', { res: 'daily', tz: 'America/New_York', start: 100, end: 200 });
+  t.throws(() => t.context.client.getCampaignMetrics(''), { message: 'campaignId is required' });
+  t.context.client.getCampaignMetrics(9, { version: '1', res: 'daily', tz: 'America/New_York', start: 100, end: 200 });
   t.true(get.calledWith(`${API}/campaigns/9/metrics?version=1&res=daily&tz=America%2FNew_York&start=100&end=200`));
 });
 
@@ -1311,7 +1308,7 @@ test('#getCampaignJourneyMetrics: requires window + resolution', (t) => {
     message: 'options.res is required',
   });
   t.context.client.getCampaignJourneyMetrics(9, { start: 100, end: 200, res: 'daily' });
-  t.true(get.calledWith(`${API}/campaigns/9/journey_metrics?start=100&end=200&res=daily`));
+  t.true(get.calledWith(`${API}/campaigns/9/journey_metrics?start=100&end=200&resolution=daily`));
 });
 
 test('#getCampaignMessages: forwards filters and validates', (t) => {
@@ -1403,16 +1400,16 @@ test('#getBroadcastActionMetrics: forwards options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getBroadcastActionMetrics('', 2), { message: 'broadcastId is required' });
   t.throws(() => t.context.client.getBroadcastActionMetrics(4, ''), { message: 'actionId is required' });
-  t.context.client.getBroadcastActionMetrics(4, 2, { period: 'days', steps: 7, type: 'email' });
-  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics?period=days&steps=7&type=email`));
+  t.context.client.getBroadcastActionMetrics(4, 2, { period: 'days', steps: 7 });
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics?period=days&steps=7`));
 });
 
 test('#getBroadcastActionMetricsLinks: forwards options and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getBroadcastActionMetricsLinks('', 2), { message: 'broadcastId is required' });
   t.throws(() => t.context.client.getBroadcastActionMetricsLinks(4, ''), { message: 'actionId is required' });
-  t.context.client.getBroadcastActionMetricsLinks(4, 2, { period: 'weeks', steps: 4, type: 'push' });
-  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics/links?period=weeks&steps=4&type=push`));
+  t.context.client.getBroadcastActionMetricsLinks(4, 2, { period: 'weeks', steps: 4, unique: true });
+  t.true(get.calledWith(`${API}/broadcasts/4/actions/2/metrics/links?period=weeks&steps=4&unique=true`));
 });
 
 test('#getBroadcastMetrics: forwards options and validates', (t) => {
@@ -1432,8 +1429,8 @@ test('#getBroadcastMetricsLinks: forwards unique and validates', (t) => {
 test('#getBroadcastMessages: forwards filters and validates', (t) => {
   const get = sinon.stub(t.context.client.request, 'get');
   t.throws(() => t.context.client.getBroadcastMessages(''), { message: 'broadcastId is required' });
-  t.context.client.getBroadcastMessages(4, { metric: 'delivered', state: 'sent', type: 'email', limit: 50 });
-  t.true(get.calledWith(`${API}/broadcasts/4/messages?limit=50&metric=delivered&state=sent&type=email`));
+  t.context.client.getBroadcastMessages(4, { metric: 'delivered', type: 'email', limit: 50 });
+  t.true(get.calledWith(`${API}/broadcasts/4/messages?limit=50&metric=delivered&type=email`));
 });
 
 test('#getBroadcastTriggers: gets the triggers endpoint and validates', (t) => {

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -240,7 +240,7 @@ needs('CIO_TEST_CAMPAIGN_ID')('campaign reads resolve for a known id', async (t)
   const start = end - 7 * 24 * 60 * 60;
   await api!.getCampaign(id).catch(() => undefined);
   await api!.getCampaignActions(id).catch(() => undefined);
-  await api!.getCampaignMetrics(id, '1', { period: 'days', steps: 7 }).catch(() => undefined);
+  await api!.getCampaignMetrics(id, { version: '1', period: 'days', steps: 7 }).catch(() => undefined);
   await api!.getCampaignMetricsLinks(id, { period: 'days', steps: 7 }).catch(() => undefined);
   await api!.getCampaignJourneyMetrics(id, { start, end, res: 'days' }).catch(() => undefined);
   await api!.getCampaignMessages(id, { limit: 5 }).catch(() => undefined);


### PR DESCRIPTION
Cross-verified **all** App API methods against the backends after we found the published OpenAPI spec drifts from the actual handlers. This fixes the SDK params that don't match reality, and the spec will be fixed separately internally.

**None of these methods shipped in v5.1.0**: they're all in unreleased batches, so there's no released-user impact.

## Fixes

| Method | Fix | Backend evidence |
|---|---|---|
| `getCampaignJourneyMetrics` | send `resolution` (not `res`) | back end reads `resolution` — previously 400'd every call |
| `getCampaignActionMetrics`, `getBroadcastActionMetrics` | drop `type` | back end hardcodes all channels |
| `getCampaignActionMetricsLinks`, `getBroadcastActionMetricsLinks` | `type` → `unique` | back end reads `unique` |
| `getBroadcastMessages`, `getTransactionalMessageDeliveries` | drop `state` | back end never reads `state` |
| `getCampaignMetrics`, `getCampaignActionMetrics` | `version` moved into options + made optional | server defaults it; never required |
| `downloadExport` | doc: returns `{ url }` not `{ link }` |

## Type changes
- Added `MetricsWindowOptions` (base window) and `CampaignActionMetricsOptions` (campaign action metrics, no `type`).
- Removed the now-unused `DeliveryState`.
- `getCampaignMetrics(campaignId, options)` / `getCampaignActionMetrics(campaignId, actionId, options)` — `version` is now an optional field in `options` rather than a required positional arg.

Assisted by AI 🤖 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking signature and query-param changes across many client methods, but PR states these APIs were not yet released; fixes include a journey-metrics bug that caused 400s.
> 
> **Overview**
> Aligns unreleased **App API** client methods with what the backend actually accepts, after audit against real handlers (not the drifting OpenAPI spec).
> 
> **Query string fixes:** `getCampaignJourneyMetrics` now sends `resolution` instead of `res` (previously broke every call). Campaign/broadcast **action** link metrics send `unique` instead of `type`. Action-level metrics no longer send `type` (all-channel aggregation). Transactional/broadcast message listings no longer send unsupported `state`.
> 
> **Signatures & types:** `getCampaignMetrics` and `getCampaignActionMetrics` drop the required positional `version` arg; `version` is optional inside `options`. Adds `MetricsWindowOptions` / `CampaignActionMetricsOptions`, removes `DeliveryState`. `downloadExport` JSDoc corrected to `{ url }`.
> 
> **Docs & tests:** `docs/app.md`, unit tests, and live integration call sites updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac5f661491662b4d12c8f8aeb12696637b14bcf3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->