### PR TITLE
feat: add App API Design Studio language & component methods

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -1478,3 +1478,141 @@ api.deleteDesignStudioEmail("2a1…");
 #### Options
 
 - **emailId**: The email's UUID (required)
+
+### api.listDesignStudioEmailLanguages(emailId)
+
+List the translations (languages) of an email.
+
+```javascript
+api.listDesignStudioEmailLanguages("2a1…");
+```
+
+#### Options
+
+- **emailId**: The email's UUID (required)
+
+### api.createDesignStudioEmailLanguage(emailId, translation)
+
+Create a translation of an email. Content blocks you omit are inherited from the default-language email.
+
+```javascript
+api.createDesignStudioEmailLanguage("2a1…", {
+  language: "fr",
+  content: { subject: "Bonjour" },
+});
+```
+
+#### Options
+
+- **emailId**: The email's UUID (required)
+- **translation**: The translation definition
+  - _language_: IETF language tag (required)
+  - _content_: `{ subject, preheader_text, html, amp, text }`
+  - _envelope_: `{ from_id, reply_to_id, recipient, bcc, fake_bcc, cc, headers }`
+  - _transformers_: Content transformers
+
+### api.getDesignStudioEmailLanguage(emailId, language)
+
+Get a single-language translation of an email.
+
+```javascript
+api.getDesignStudioEmailLanguage("2a1…", "fr");
+```
+
+#### Options
+
+- **emailId**: The email's UUID (required)
+- **language**: The IETF language tag (required)
+
+### api.updateDesignStudioEmailLanguage(emailId, language, updates)
+
+Update a translation. At least one field must be provided. The language itself is immutable. Returns no content on success.
+
+```javascript
+api.updateDesignStudioEmailLanguage("2a1…", "fr", { content: { subject: "Salut" } });
+```
+
+#### Options
+
+- **emailId**: The email's UUID (required)
+- **language**: The IETF language tag (required)
+- **updates**: Object with any of `content`, `envelope`, `transformers`
+
+### api.deleteDesignStudioEmailLanguage(emailId, language)
+
+Delete a translation. Returns no content on success.
+
+```javascript
+api.deleteDesignStudioEmailLanguage("2a1…", "fr");
+```
+
+#### Options
+
+- **emailId**: The email's UUID (required)
+- **language**: The IETF language tag (required)
+
+### api.listDesignStudioComponents(options)
+
+List Design Studio components.
+
+```javascript
+api.listDesignStudioComponents({ tag: "header", limit: 25 });
+```
+
+#### Options
+
+- **options**: Object (optional) — the shared list filters described above, plus:
+  - _tag_: Only list components with this tag
+
+### api.createDesignStudioComponent(component)
+
+Create a component.
+
+```javascript
+api.createDesignStudioComponent({ name: "Header", tag: "header", content: "<div>…</div>" });
+```
+
+#### Options
+
+- **component**: The component definition
+  - _name_: The component's display name (required)
+  - _tag_: The component's tag, unique per workspace (required)
+  - _parent_folder_id_: Parent folder UUID, or `null`/omit for the root
+  - _content_: The component's HTML content
+
+### api.getDesignStudioComponent(componentId)
+
+Get a single component.
+
+```javascript
+api.getDesignStudioComponent("3b2…");
+```
+
+#### Options
+
+- **componentId**: The component's UUID (required)
+
+### api.updateDesignStudioComponent(componentId, updates)
+
+Update a component. At least one field must be provided. Returns no content on success.
+
+```javascript
+api.updateDesignStudioComponent("3b2…", { content: "<div>updated</div>" });
+```
+
+#### Options
+
+- **componentId**: The component's UUID (required)
+- **updates**: Object with any of `name`, `tag`, `parent_folder_id`, `content`
+
+### api.deleteDesignStudioComponent(componentId)
+
+Delete a component. Returns no content on success.
+
+```javascript
+api.deleteDesignStudioComponent("3b2…");
+```
+
+#### Options
+
+- **componentId**: The component's UUID (required)

--- a/docs/app.md
+++ b/docs/app.md
@@ -1616,3 +1616,152 @@ api.deleteDesignStudioComponent("3b2…");
 #### Options
 
 - **componentId**: The component's UUID (required)
+
+## Assets
+
+Manage uploaded files (images, PDFs) and the folders that organize them. Asset and folder ids are **integers**.
+
+The list endpoints share folder filtering and page-based pagination:
+
+- **parentFolderId**: Only list items within this folder id (omit for all/root)
+- **directDescendantsOnly**: When `true`, return only direct children rather than the whole subtree
+- **page**: 1-based page number (default 1)
+- **limit**: page size, 1–10000 (default 1000)
+
+On file and folder updates, `parent_folder_id` is tri-state: **omit** to keep the current parent, pass `null` to move to the root, or pass a folder id to move it.
+
+### api.listAssets(options)
+
+List uploaded files.
+
+```javascript
+api.listAssets({ parentFolderId: 5, limit: 50 });
+```
+
+#### Options
+
+- **options**: Object (optional) — `parentFolderId`, `directDescendantsOnly`, `page`, `limit`
+
+### api.createAsset(file)
+
+Upload a file (`multipart/form-data`). The API accepts images (`image/bmp`, `image/jpeg`, `image/jpg`, `image/png`, `image/gif`) and `application/pdf`, up to 2 MB (images max 4096px per side).
+
+```javascript
+const fs = require("fs");
+
+api.createAsset({
+  data: fs.readFileSync("logo.png"),
+  filename: "logo.png",
+  contentType: "image/png",
+  parentFolderId: 5,
+});
+```
+
+#### Options
+
+- **file**: The upload definition
+  - _data_: File contents — any `Buffer`/`Blob`-compatible value (required)
+  - _filename_: Filename; also the default asset name and, when `contentType` is omitted, the source for the derived content type (required)
+  - _contentType_: MIME type of the upload; when omitted the SDK derives it from the filename extension (`.bmp`, `.jpg`/`.jpeg`, `.png`, `.gif`, `.pdf`)
+  - _name_: Asset name; defaults to `filename`
+  - _parentFolderId_: Parent folder id; omit for the root
+
+### api.getAsset(assetId)
+
+Get a single file.
+
+```javascript
+api.getAsset(42);
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+
+### api.updateAsset(assetId, updates)
+
+Rename and/or move a file. At least one field must be provided; the file bytes cannot be changed. Returns no content on success.
+
+```javascript
+api.updateAsset(42, { name: "renamed.png", parent_folder_id: null });
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+- **updates**: Object with any of `name`, `parent_folder_id`
+
+### api.deleteAsset(assetId)
+
+Delete a file. Returns no content on success.
+
+```javascript
+api.deleteAsset(42);
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+
+### api.listAssetFolders(options)
+
+List asset folders.
+
+```javascript
+api.listAssetFolders({ parentFolderId: 5, limit: 50 });
+```
+
+#### Options
+
+- **options**: Object (optional) — `parentFolderId`, `directDescendantsOnly`, `page`, `limit`
+
+### api.createAssetFolder(folder)
+
+Create an asset folder.
+
+```javascript
+api.createAssetFolder({ name: "Product images", parent_folder_id: 5 });
+```
+
+#### Options
+
+- **folder**: The folder definition
+  - _name_: The folder's display name (required)
+  - _parent_folder_id_: Parent folder id; omit for the root
+
+### api.getAssetFolder(folderId)
+
+Get a single asset folder.
+
+```javascript
+api.getAssetFolder(5);
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)
+
+### api.updateAssetFolder(folderId, updates)
+
+Rename and/or move a folder. At least one field must be provided. Returns no content on success.
+
+```javascript
+api.updateAssetFolder(5, { name: "Renamed", parent_folder_id: null });
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)
+- **updates**: Object with any of `name`, `parent_folder_id`
+
+### api.deleteAssetFolder(folderId)
+
+Delete an asset folder. The folder must be empty.
+
+```javascript
+api.deleteAssetFolder(5);
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -406,6 +406,93 @@ export type DesignStudioComponentUpdate = {
   content?: string;
 };
 
+/** Filters and pagination shared by the asset list endpoints (page-based). */
+export type AssetListOptions = {
+  /** Only list assets directly within this folder id (omit for all/root). */
+  parentFolderId?: number;
+  /** When `true`, return only direct children rather than the whole subtree. */
+  directDescendantsOnly?: boolean;
+  /** 1-based page number. Defaults to 1. */
+  page?: number;
+  /** Page size, 1–10000. Defaults to 1000. */
+  limit?: number;
+};
+
+/**
+ * Definition for uploading a file via {@link APIClient.createAsset}.
+ *
+ * The API accepts images (`image/bmp`, `image/jpeg`, `image/jpg`, `image/png`,
+ * `image/gif`) and `application/pdf`, up to 2 MB (images max 4096px per side).
+ */
+export type CreateAssetInput = {
+  /** File contents. A `Uint8Array` (a `Buffer`, e.g. from `fs.readFileSync`, is one), `ArrayBuffer`, `Blob`, or `string`. */
+  data: Uint8Array | ArrayBuffer | Blob | string;
+  /** Filename — also the multipart filename, the default asset `name`, and (when `contentType` is omitted) the source for the derived content type. */
+  filename: string;
+  /**
+   * MIME type of the upload. When omitted, the SDK derives it from the `filename` extension
+   * for the accepted image/PDF types (`.bmp`, `.jpg`/`.jpeg`, `.png`, `.gif`, `.pdf`).
+   */
+  contentType?: string;
+  /** Asset name. Defaults to `filename`. */
+  name?: string;
+  /** Parent folder id. Omit for the root. */
+  parentFolderId?: number;
+};
+
+/**
+ * Accepted upload extensions mapped to their MIME type. Used to set the multipart
+ * part's `Content-Type` client-side when the caller omits `contentType`: an untyped
+ * `Blob` is serialized as `application/octet-stream`, which the Assets API rejects,
+ * and the API's own extension fallback only runs when the part carries no type at all.
+ */
+const ASSET_CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  bmp: 'image/bmp',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  pdf: 'application/pdf',
+};
+
+/** Derive an accepted asset MIME type from a filename's extension, or `undefined` if unrecognized. */
+const assetContentTypeForFilename = (filename: string): string | undefined => {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) {
+    return undefined;
+  }
+
+  return ASSET_CONTENT_TYPE_BY_EXTENSION[filename.slice(dot + 1).toLowerCase()];
+};
+
+/**
+ * Fields for updating an asset via {@link APIClient.updateAsset}. At least one must be provided;
+ * file bytes cannot be changed. `parent_folder_id` is tri-state: omit to keep the current parent,
+ * `null` to move to the root, or a folder id to move it into that folder.
+ */
+export type AssetUpdate = {
+  name?: string;
+  parent_folder_id?: number | null;
+};
+
+/** Definition for creating an asset folder via {@link APIClient.createAssetFolder}. */
+export type AssetFolderInput = {
+  /** The folder's display name (required). */
+  name: string;
+  /** Parent folder id. Omit for the root. */
+  parent_folder_id?: number;
+};
+
+/**
+ * Fields for updating an asset folder via {@link APIClient.updateAssetFolder}. At least one must
+ * be provided. `parent_folder_id` is tri-state: omit to keep the current parent, `null` to move to
+ * the root, or a folder id to move it into that folder.
+ */
+export type AssetFolderUpdate = {
+  name?: string;
+  parent_folder_id?: number | null;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -2900,6 +2987,205 @@ export class APIClient {
     }
 
     return this.request.destroy(`${this.apiRoot}/design_studio/components/${encodeURIComponent(componentId)}`);
+  }
+
+  /**
+   * List uploaded assets (files).
+   *
+   * @param options Optional folder filter and pagination. See {@link AssetListOptions}.
+   * @returns The parsed JSON response body (`{ assets: [...], meta }`).
+   */
+  listAssets(options: AssetListOptions = {}) {
+    const query = buildQueryString({
+      parent_folder_id: options.parentFolderId,
+      direct_descendants_only: options.directDescendantsOnly,
+      page: options.page,
+      limit: options.limit,
+    });
+
+    return this.request.get(`${this.apiRoot}/assets${query}`);
+  }
+
+  /**
+   * Upload a file asset (`multipart/form-data`).
+   *
+   * @param file The file to upload. `data` and `filename` are required. See {@link CreateAssetInput}.
+   * @returns The parsed JSON response body (`{ asset: {...} }`).
+   * @throws {MissingParamError} If `file` is missing/not an object, or `file.data`/`file.filename` is missing.
+   */
+  createAsset(file: CreateAssetInput) {
+    if (file == null || typeof file !== 'object') {
+      throw new MissingParamError('file');
+    }
+
+    if (file.data == null) {
+      throw new MissingParamError('file.data');
+    }
+
+    if (isEmpty(file.filename)) {
+      throw new MissingParamError('file.filename');
+    }
+
+    // Set the part's Content-Type explicitly. An untyped Blob is serialized as
+    // `application/octet-stream`, which the API rejects, so resolve a type from
+    // (in order) an explicit `contentType`, the filename extension, or the type
+    // already on `data` when it is a Blob. An empty-string `contentType` is
+    // treated as absent so it still falls through to derivation.
+    const explicitType = isEmpty(file.contentType) ? undefined : file.contentType;
+    const contentType =
+      explicitType ??
+      assetContentTypeForFilename(file.filename) ??
+      (file.data instanceof Blob && file.data.type ? file.data.type : undefined);
+    const form = new FormData();
+    const blob = contentType ? new Blob([file.data], { type: contentType }) : new Blob([file.data]);
+    form.append('file', blob, file.filename);
+
+    if (file.name !== undefined) {
+      form.append('name', file.name);
+    }
+
+    if (file.parentFolderId !== undefined) {
+      form.append('parent_folder_id', String(file.parentFolderId));
+    }
+
+    return this.request.postForm(`${this.apiRoot}/assets/files`, form);
+  }
+
+  /**
+   * Get a single asset (file).
+   *
+   * @param assetId The asset's numeric id.
+   * @returns The parsed JSON response body (`{ asset: {...} }`).
+   * @throws {MissingParamError} If `assetId` is empty.
+   */
+  getAsset(assetId: string | number) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    return this.request.get(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`);
+  }
+
+  /**
+   * Update an asset's name and/or parent folder. At least one field must be provided;
+   * the file bytes cannot be changed.
+   *
+   * @param assetId The asset's numeric id.
+   * @param updates The fields to change. See {@link AssetUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `assetId` is empty or `updates` is missing/not an object.
+   */
+  updateAsset(assetId: string | number, updates: AssetUpdate) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`, updates);
+  }
+
+  /**
+   * Delete an asset (file).
+   *
+   * @param assetId The asset's numeric id.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `assetId` is empty.
+   */
+  deleteAsset(assetId: string | number) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    return this.request.destroy(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`);
+  }
+
+  /**
+   * List asset folders.
+   *
+   * @param options Optional folder filter and pagination. See {@link AssetListOptions}.
+   * @returns The parsed JSON response body (`{ folders: [...], meta }`).
+   */
+  listAssetFolders(options: AssetListOptions = {}) {
+    const query = buildQueryString({
+      parent_folder_id: options.parentFolderId,
+      direct_descendants_only: options.directDescendantsOnly,
+      page: options.page,
+      limit: options.limit,
+    });
+
+    return this.request.get(`${this.apiRoot}/assets/folders${query}`);
+  }
+
+  /**
+   * Create an asset folder.
+   *
+   * @param folder The folder definition. `name` is required. See {@link AssetFolderInput}.
+   * @returns The parsed JSON response body (`{ folder: {...} }`).
+   * @throws {MissingParamError} If `folder` is missing/not an object, or `folder.name` is empty.
+   */
+  createAssetFolder(folder: AssetFolderInput) {
+    if (folder == null || typeof folder !== 'object') {
+      throw new MissingParamError('folder');
+    }
+
+    if (isEmpty(folder.name)) {
+      throw new MissingParamError('folder.name');
+    }
+
+    return this.request.post(`${this.apiRoot}/assets/folders`, folder);
+  }
+
+  /**
+   * Get a single asset folder.
+   *
+   * @param folderId The folder's numeric id.
+   * @returns The parsed JSON response body (`{ folder: {...} }`).
+   * @throws {MissingParamError} If `folderId` is empty.
+   */
+  getAssetFolder(folderId: string | number) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    return this.request.get(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`);
+  }
+
+  /**
+   * Update an asset folder. At least one field must be provided.
+   *
+   * @param folderId The folder's numeric id.
+   * @param updates The fields to change. See {@link AssetFolderUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `folderId` is empty or `updates` is missing/not an object.
+   */
+  updateAssetFolder(folderId: string | number, updates: AssetFolderUpdate) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`, updates);
+  }
+
+  /**
+   * Delete an asset folder. The folder must be empty.
+   *
+   * @param folderId The folder's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `folderId` is empty.
+   */
+  deleteAssetFolder(folderId: string | number) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    return this.request.destroy(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`);
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -356,6 +356,56 @@ export type DesignStudioFolderUpdate = {
   parent_folder_id?: string | null;
 };
 
+/** Definition for creating a Design Studio email translation via {@link APIClient.createDesignStudioEmailLanguage}. */
+export type DesignStudioEmailTranslationInput = {
+  /** IETF language tag for the translation (required). */
+  language: string;
+  /** Content overrides. Omitted blocks are inherited from the default-language email. */
+  content?: DesignStudioEmailContent;
+  envelope?: DesignStudioEmailEnvelope;
+  transformers?: Record<string, any>;
+};
+
+/**
+ * Fields for updating a Design Studio email translation via {@link APIClient.updateDesignStudioEmailLanguage}.
+ * At least one must be provided. The language itself is immutable (taken from the path).
+ */
+export type DesignStudioEmailTranslationUpdate = {
+  content?: DesignStudioEmailContent;
+  envelope?: DesignStudioEmailEnvelope;
+  transformers?: Record<string, any>;
+};
+
+/** Options for {@link APIClient.listDesignStudioComponents}. */
+export type ListDesignStudioComponentsOptions = DesignStudioListOptions & {
+  /** Only list components with this tag. */
+  tag?: string;
+};
+
+/** Definition for creating a Design Studio component via {@link APIClient.createDesignStudioComponent}. */
+export type DesignStudioComponentInput = {
+  /** The component's display name (required). */
+  name: string;
+  /** The component's tag — unique per workspace (required). */
+  tag: string;
+  /** Parent folder UUID. Omit or pass `null` for the root. */
+  parent_folder_id?: string | null;
+  /** The component's HTML content. */
+  content?: string;
+};
+
+/**
+ * Fields for updating a Design Studio component via {@link APIClient.updateDesignStudioComponent}.
+ * At least one must be provided. `parent_folder_id` is tri-state: omit to keep the current parent,
+ * `null` to move to the root, or a UUID to move into that folder.
+ */
+export type DesignStudioComponentUpdate = {
+  name?: string;
+  tag?: string;
+  parent_folder_id?: string | null;
+  content?: string;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -2638,6 +2688,218 @@ export class APIClient {
     }
 
     return this.request.destroy(`${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}`);
+  }
+
+  /**
+   * List the translations (languages) of a Design Studio email.
+   *
+   * @param emailId The email's UUID.
+   * @returns The parsed JSON response body (`{ email_translations: [...] }`).
+   * @throws {MissingParamError} If `emailId` is empty.
+   */
+  listDesignStudioEmailLanguages(emailId: string) {
+    if (isEmpty(emailId)) {
+      throw new MissingParamError('emailId');
+    }
+
+    return this.request.get(`${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}/languages`);
+  }
+
+  /**
+   * Create a translation of a Design Studio email. Content blocks you omit are
+   * inherited from the default-language email.
+   *
+   * @param emailId The email's UUID.
+   * @param translation The translation definition. `language` is required. See {@link DesignStudioEmailTranslationInput}.
+   * @returns The parsed JSON response body (`{ email_translation: {...} }`).
+   * @throws {MissingParamError} If `emailId` is empty, `translation` is missing/not an object, or `translation.language` is empty.
+   */
+  createDesignStudioEmailLanguage(emailId: string, translation: DesignStudioEmailTranslationInput) {
+    if (isEmpty(emailId)) {
+      throw new MissingParamError('emailId');
+    }
+
+    if (translation == null || typeof translation !== 'object') {
+      throw new MissingParamError('translation');
+    }
+
+    if (isEmpty(translation.language)) {
+      throw new MissingParamError('translation.language');
+    }
+
+    return this.request.post(
+      `${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}/languages`,
+      translation,
+    );
+  }
+
+  /**
+   * Get a single-language translation of a Design Studio email.
+   *
+   * @param emailId The email's UUID.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body (`{ email_translation: {...} }`).
+   * @throws {MissingParamError} If `emailId` or `language` is empty.
+   */
+  getDesignStudioEmailLanguage(emailId: string, language: string) {
+    if (isEmpty(emailId)) {
+      throw new MissingParamError('emailId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.get(
+      `${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}/languages/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * Update a single-language translation of a Design Studio email. At least one field must be provided.
+   *
+   * @param emailId The email's UUID.
+   * @param language The IETF language tag.
+   * @param updates The fields to change. See {@link DesignStudioEmailTranslationUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `emailId` or `language` is empty, or `updates` is missing/not an object.
+   */
+  updateDesignStudioEmailLanguage(emailId: string, language: string, updates: DesignStudioEmailTranslationUpdate) {
+    if (isEmpty(emailId)) {
+      throw new MissingParamError('emailId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(
+      `${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}/languages/${encodeURIComponent(language)}`,
+      updates,
+    );
+  }
+
+  /**
+   * Delete a single-language translation of a Design Studio email.
+   *
+   * @param emailId The email's UUID.
+   * @param language The IETF language tag.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `emailId` or `language` is empty.
+   */
+  deleteDesignStudioEmailLanguage(emailId: string, language: string) {
+    if (isEmpty(emailId)) {
+      throw new MissingParamError('emailId');
+    }
+
+    if (isEmpty(language)) {
+      throw new MissingParamError('language');
+    }
+
+    return this.request.destroy(
+      `${this.apiRoot}/design_studio/emails/${encodeURIComponent(emailId)}/languages/${encodeURIComponent(language)}`,
+    );
+  }
+
+  /**
+   * List Design Studio components.
+   *
+   * @param options Optional filters, sorting, and pagination. See {@link ListDesignStudioComponentsOptions}.
+   * @returns The parsed JSON response body (`{ components: [...], folders: [...], meta }`).
+   */
+  listDesignStudioComponents(options: ListDesignStudioComponentsOptions = {}) {
+    const query = buildQueryString({
+      parent_folder_id: options.parentFolderId,
+      direct_descendants_only: options.directDescendantsOnly,
+      sort_by: options.sortBy,
+      sort_order: options.sortOrder,
+      created_before: options.createdBefore,
+      created_after: options.createdAfter,
+      updated_before: options.updatedBefore,
+      updated_after: options.updatedAfter,
+      page: options.page,
+      limit: options.limit,
+      tag: options.tag,
+    });
+
+    return this.request.get(`${this.apiRoot}/design_studio/components${query}`);
+  }
+
+  /**
+   * Create a Design Studio component.
+   *
+   * @param component The component definition. `name` and `tag` are required. See {@link DesignStudioComponentInput}.
+   * @returns The parsed JSON response body (`{ component: {...} }`).
+   * @throws {MissingParamError} If `component` is missing/not an object, or `component.name`/`component.tag` is empty.
+   */
+  createDesignStudioComponent(component: DesignStudioComponentInput) {
+    if (component == null || typeof component !== 'object') {
+      throw new MissingParamError('component');
+    }
+
+    if (isEmpty(component.name)) {
+      throw new MissingParamError('component.name');
+    }
+
+    if (isEmpty(component.tag)) {
+      throw new MissingParamError('component.tag');
+    }
+
+    return this.request.post(`${this.apiRoot}/design_studio/components`, component);
+  }
+
+  /**
+   * Get a single Design Studio component.
+   *
+   * @param componentId The component's UUID.
+   * @returns The parsed JSON response body (`{ component: {...} }`).
+   * @throws {MissingParamError} If `componentId` is empty.
+   */
+  getDesignStudioComponent(componentId: string) {
+    if (isEmpty(componentId)) {
+      throw new MissingParamError('componentId');
+    }
+
+    return this.request.get(`${this.apiRoot}/design_studio/components/${encodeURIComponent(componentId)}`);
+  }
+
+  /**
+   * Update a Design Studio component. At least one field must be provided.
+   *
+   * @param componentId The component's UUID.
+   * @param updates The fields to change. See {@link DesignStudioComponentUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `componentId` is empty or `updates` is missing/not an object.
+   */
+  updateDesignStudioComponent(componentId: string, updates: DesignStudioComponentUpdate) {
+    if (isEmpty(componentId)) {
+      throw new MissingParamError('componentId');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(`${this.apiRoot}/design_studio/components/${encodeURIComponent(componentId)}`, updates);
+  }
+
+  /**
+   * Delete a Design Studio component.
+   *
+   * @param componentId The component's UUID.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `componentId` is empty.
+   */
+  deleteDesignStudioComponent(componentId: string) {
+    if (isEmpty(componentId)) {
+      throw new MissingParamError('componentId');
+    }
+
+    return this.request.destroy(`${this.apiRoot}/design_studio/components/${encodeURIComponent(componentId)}`);
   }
 }
 

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -35,7 +35,7 @@ export interface RequestHandlerOptions {
   method: string;
   uri: string;
   headers: Record<string, string | number>;
-  body?: string | null;
+  body?: string | FormData | null;
 }
 export interface PushRequestData {
   delivery_id?: string;
@@ -150,6 +150,31 @@ export default class CIORequest {
     }
 
     return { method, uri, headers, body };
+  }
+
+  /**
+   * Build request options for a `multipart/form-data` upload. Unlike
+   * {@link options}, the `Content-Type` is deliberately left unset so `fetch`
+   * adds it with the correct multipart boundary, and no `Content-Length` is
+   * computed (the runtime streams the body).
+   */
+  formOptions(uri: string, method: string, form: FormData): RequestHandlerOptions {
+    const customHeaders = (this.defaults.headers ?? {}) as Record<string, string | number>;
+    const headers: Record<string, string | number> = {};
+
+    // Merge caller headers, but never a Content-Type: multipart uploads rely on
+    // `fetch` setting `multipart/form-data` with a boundary, so a stray
+    // Content-Type from `defaults.headers` would corrupt the request body.
+    for (const [key, value] of Object.entries(customHeaders)) {
+      if (key.toLowerCase() !== 'content-type') {
+        headers[key] = value;
+      }
+    }
+
+    headers.Authorization = this.auth;
+    headers['User-Agent'] = `Customer.io Node Client/${version}`;
+
+    return { method, uri, headers, body: form };
   }
 
   private async execute({ uri, body, method, headers }: RequestHandlerOptions): Promise<Record<string, any>> {
@@ -339,5 +364,9 @@ export default class CIORequest {
 
   post(uri: string, data: RequestData = {}) {
     return this.handler(this.options(uri, 'POST', data));
+  }
+
+  postForm(uri: string, form: FormData) {
+    return this.handler(this.formOptions(uri, 'POST', form));
   }
 }

--- a/test/api.ts
+++ b/test/api.ts
@@ -1858,3 +1858,114 @@ test('#deleteDesignStudioEmail: deletes an email and validates', (t) => {
   t.context.client.deleteDesignStudioEmail('email-1');
   t.true(destroy.calledWith(`${API}/design_studio/emails/email-1`));
 });
+
+// Design Studio: email languages (translations)
+
+test('#listDesignStudioEmailLanguages: gets the languages endpoint and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.listDesignStudioEmailLanguages(''), { message: 'emailId is required' });
+  t.context.client.listDesignStudioEmailLanguages('email-1');
+  t.true(get.calledWith(`${API}/design_studio/emails/email-1/languages`));
+});
+
+test('#createDesignStudioEmailLanguage: posts the translation body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => (t.context.client.createDesignStudioEmailLanguage as any)('', { language: 'fr' }), {
+    message: 'emailId is required',
+  });
+  t.throws(() => (t.context.client.createDesignStudioEmailLanguage as any)('email-1', null), {
+    message: 'translation is required',
+  });
+  t.throws(() => (t.context.client.createDesignStudioEmailLanguage as any)('email-1', {}), {
+    message: 'translation.language is required',
+  });
+  const translation = { language: 'fr', content: { subject: 'Bonjour' } };
+  t.context.client.createDesignStudioEmailLanguage('email-1', translation);
+  t.true(post.calledWith(`${API}/design_studio/emails/email-1/languages`, translation));
+});
+
+test('#getDesignStudioEmailLanguage: gets a single translation and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getDesignStudioEmailLanguage('', 'fr'), { message: 'emailId is required' });
+  t.throws(() => t.context.client.getDesignStudioEmailLanguage('email-1', ''), { message: 'language is required' });
+  t.context.client.getDesignStudioEmailLanguage('email-1', 'fr');
+  t.true(get.calledWith(`${API}/design_studio/emails/email-1/languages/fr`));
+});
+
+test('#updateDesignStudioEmailLanguage: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateDesignStudioEmailLanguage('', 'fr', { content: {} }), {
+    message: 'emailId is required',
+  });
+  t.throws(() => t.context.client.updateDesignStudioEmailLanguage('email-1', '', { content: {} }), {
+    message: 'language is required',
+  });
+  t.throws(() => (t.context.client.updateDesignStudioEmailLanguage as any)('email-1', 'fr', null), {
+    message: 'updates is required',
+  });
+  const updates = { content: { subject: 'Salut' } };
+  t.context.client.updateDesignStudioEmailLanguage('email-1', 'fr', updates);
+  t.true(put.calledWith(`${API}/design_studio/emails/email-1/languages/fr`, updates));
+});
+
+test('#deleteDesignStudioEmailLanguage: deletes a translation and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteDesignStudioEmailLanguage('', 'fr'), { message: 'emailId is required' });
+  t.throws(() => t.context.client.deleteDesignStudioEmailLanguage('email-1', ''), { message: 'language is required' });
+  t.context.client.deleteDesignStudioEmailLanguage('email-1', 'fr');
+  t.true(destroy.calledWith(`${API}/design_studio/emails/email-1/languages/fr`));
+});
+
+// Design Studio: components
+
+test('#listDesignStudioComponents: gets the components endpoint with no query by default', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listDesignStudioComponents();
+  t.true(get.calledWith(`${API}/design_studio/components`));
+});
+
+test('#listDesignStudioComponents: forwards base filters plus tag', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listDesignStudioComponents({ parentFolderId: 'folder-1', sortBy: 'name', limit: 10, tag: 'header' });
+  t.true(get.calledWith(`${API}/design_studio/components?parent_folder_id=folder-1&sort_by=name&limit=10&tag=header`));
+});
+
+test('#createDesignStudioComponent: posts the component body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => (t.context.client.createDesignStudioComponent as any)(null), { message: 'component is required' });
+  t.throws(() => (t.context.client.createDesignStudioComponent as any)({ tag: 'header' }), {
+    message: 'component.name is required',
+  });
+  t.throws(() => (t.context.client.createDesignStudioComponent as any)({ name: 'Header' }), {
+    message: 'component.tag is required',
+  });
+  const component = { name: 'Header', tag: 'header', content: '<div></div>' };
+  t.context.client.createDesignStudioComponent(component);
+  t.true(post.calledWith(`${API}/design_studio/components`, component));
+});
+
+test('#getDesignStudioComponent: gets a single component and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getDesignStudioComponent(''), { message: 'componentId is required' });
+  t.context.client.getDesignStudioComponent('comp-1');
+  t.true(get.calledWith(`${API}/design_studio/components/comp-1`));
+});
+
+test('#updateDesignStudioComponent: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateDesignStudioComponent('', { name: 'x' }), {
+    message: 'componentId is required',
+  });
+  t.throws(() => (t.context.client.updateDesignStudioComponent as any)('comp-1', null), {
+    message: 'updates is required',
+  });
+  t.context.client.updateDesignStudioComponent('comp-1', { tag: 'footer', parent_folder_id: null });
+  t.true(put.calledWith(`${API}/design_studio/components/comp-1`, { tag: 'footer', parent_folder_id: null }));
+});
+
+test('#deleteDesignStudioComponent: deletes a component and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteDesignStudioComponent(''), { message: 'componentId is required' });
+  t.context.client.deleteDesignStudioComponent('comp-1');
+  t.true(destroy.calledWith(`${API}/design_studio/components/comp-1`));
+});

--- a/test/api.ts
+++ b/test/api.ts
@@ -1969,3 +1969,145 @@ test('#deleteDesignStudioComponent: deletes a component and validates', (t) => {
   t.context.client.deleteDesignStudioComponent('comp-1');
   t.true(destroy.calledWith(`${API}/design_studio/components/comp-1`));
 });
+
+// Assets: files
+
+test('#listAssets: gets the assets endpoint with no query by default', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssets();
+  t.true(get.calledWith(`${API}/assets`));
+});
+
+test('#listAssets: forwards folder filter and pagination', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssets({ parentFolderId: 5, directDescendantsOnly: true, page: 2, limit: 50 });
+  t.true(get.calledWith(`${API}/assets?parent_folder_id=5&direct_descendants_only=true&page=2&limit=50`));
+});
+
+test('#createAsset: uploads a multipart form with all fields', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.throws(() => (t.context.client.createAsset as any)(null), { message: 'file is required' });
+  t.throws(() => (t.context.client.createAsset as any)({ filename: 'a.png' }), { message: 'file.data is required' });
+  t.throws(() => (t.context.client.createAsset as any)({ data: Buffer.from('x') }), {
+    message: 'file.filename is required',
+  });
+
+  t.context.client.createAsset({
+    data: Buffer.from('hello'),
+    filename: 'hello.png',
+    contentType: 'image/png',
+    name: 'Hello',
+    parentFolderId: 7,
+  });
+
+  t.true(postForm.calledOnce);
+  const [uri, form] = postForm.getCall(0).args as [string, FormData];
+  t.is(uri, `${API}/assets/files`);
+  const filePart = form.get('file') as any;
+  t.is(filePart.type, 'image/png');
+  t.is(filePart.name, 'hello.png');
+  t.is(form.get('name'), 'Hello');
+  t.is(form.get('parent_folder_id'), '7');
+});
+
+test('#createAsset: derives the content type from the filename when unset', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.PNG' });
+
+  const form = postForm.getCall(0).args[1] as FormData;
+  const filePart = form.get('file') as any;
+  // Derived from the (case-insensitive) extension, so the wire part is not application/octet-stream.
+  t.is(filePart.type, 'image/png');
+  t.is(form.get('name'), null);
+  t.is(form.get('parent_folder_id'), null);
+});
+
+test('#createAsset: treats an empty contentType as absent and derives from the filename', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.png', contentType: '' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, 'image/png');
+});
+
+test('#createAsset: preserves the type of a Blob passed as data when nothing else resolves', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: new Blob([Buffer.from('hello')], { type: 'image/gif' }), filename: 'noext' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, 'image/gif');
+});
+
+test('#createAsset: leaves the content type unset for an unrecognized extension', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'notes' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, '');
+});
+
+test('#getAsset: gets a single asset and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getAsset(''), { message: 'assetId is required' });
+  t.context.client.getAsset(3);
+  t.true(get.calledWith(`${API}/assets/files/3`));
+});
+
+test('#updateAsset: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateAsset('', { name: 'x' }), { message: 'assetId is required' });
+  t.throws(() => (t.context.client.updateAsset as any)(3, null), { message: 'updates is required' });
+  t.context.client.updateAsset(3, { name: 'Renamed', parent_folder_id: null });
+  t.true(put.calledWith(`${API}/assets/files/3`, { name: 'Renamed', parent_folder_id: null }));
+});
+
+test('#deleteAsset: deletes an asset and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteAsset(''), { message: 'assetId is required' });
+  t.context.client.deleteAsset(3);
+  t.true(destroy.calledWith(`${API}/assets/files/3`));
+});
+
+// Assets: folders
+
+test('#listAssetFolders: gets the folders endpoint with no query by default', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssetFolders();
+  t.true(get.calledWith(`${API}/assets/folders`));
+});
+
+test('#listAssetFolders: forwards folder filter and pagination', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssetFolders({ parentFolderId: 5, limit: 10 });
+  t.true(get.calledWith(`${API}/assets/folders?parent_folder_id=5&limit=10`));
+});
+
+test('#createAssetFolder: posts the folder body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => (t.context.client.createAssetFolder as any)(null), { message: 'folder is required' });
+  t.throws(() => (t.context.client.createAssetFolder as any)({}), { message: 'folder.name is required' });
+  t.context.client.createAssetFolder({ name: 'Images', parent_folder_id: 2 });
+  t.true(post.calledWith(`${API}/assets/folders`, { name: 'Images', parent_folder_id: 2 }));
+});
+
+test('#getAssetFolder: gets a single folder and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getAssetFolder(''), { message: 'folderId is required' });
+  t.context.client.getAssetFolder(2);
+  t.true(get.calledWith(`${API}/assets/folders/2`));
+});
+
+test('#updateAssetFolder: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateAssetFolder('', { name: 'x' }), { message: 'folderId is required' });
+  t.throws(() => (t.context.client.updateAssetFolder as any)(2, null), { message: 'updates is required' });
+  t.context.client.updateAssetFolder(2, { name: 'Renamed', parent_folder_id: null });
+  t.true(put.calledWith(`${API}/assets/folders/2`, { name: 'Renamed', parent_folder_id: null }));
+});
+
+test('#deleteAssetFolder: deletes a folder and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteAssetFolder(''), { message: 'folderId is required' });
+  t.context.client.deleteAssetFolder(2);
+  t.true(destroy.calledWith(`${API}/assets/folders/2`));
+});

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -381,6 +381,50 @@ liveTest('design studio component create -> read -> update -> delete round-trip'
   t.pass();
 });
 
+liveTest('listAssets resolves', async (t) => {
+  const result = (await api!.listAssets({ limit: 5 })) as { assets?: unknown };
+  t.true('assets' in result);
+});
+
+liveTest('listAssetFolders resolves', async (t) => {
+  const result = (await api!.listAssetFolders({ limit: 5 })) as { folders?: unknown };
+  t.true('folders' in result);
+});
+
+liveTest('asset folder + file create -> read -> update -> delete round-trip', async (t) => {
+  // A minimal valid 1x1 PNG — the backend validates that uploads are real images.
+  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+  const pngBytes = Buffer.from(pngBase64, 'base64');
+
+  const folder = (await api!.createAssetFolder({ name: `sdk-live-assets-${customerId}` }).catch(() => undefined)) as
+    | { folder?: { id?: number } }
+    | undefined;
+  const folderId = folder?.folder?.id;
+
+  const uploaded = (await api!
+    .createAsset({
+      data: pngBytes,
+      // No contentType: exercises the filename-extension derivation end-to-end.
+      filename: `sdk-live-${customerId}.png`,
+      parentFolderId: folderId,
+    })
+    .catch(() => undefined)) as { asset?: { id?: number } } | undefined;
+  const assetId = uploaded?.asset?.id;
+
+  if (assetId !== undefined) {
+    await api!.getAsset(assetId).catch(() => undefined);
+    await api!.updateAsset(assetId, { name: `sdk-live-${customerId}-renamed.png` }).catch(() => undefined);
+    await api!.deleteAsset(assetId).catch(() => undefined);
+  }
+
+  if (folderId !== undefined) {
+    await api!.getAssetFolder(folderId).catch(() => undefined);
+    await api!.deleteAssetFolder(folderId).catch(() => undefined);
+  }
+
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -336,6 +336,18 @@ liveTest('design studio folder + email create -> read -> update -> delete round-
     if (emailId) {
       await api!.getDesignStudioEmail(emailId).catch(() => undefined);
       await api!.updateDesignStudioEmail(emailId, { is_template: true }).catch(() => undefined);
+
+      // Email translations (languages).
+      await api!.listDesignStudioEmailLanguages(emailId).catch(() => undefined);
+      await api!
+        .createDesignStudioEmailLanguage(emailId, { language: 'fr', content: { subject: 'Bonjour' } })
+        .catch(() => undefined);
+      await api!.getDesignStudioEmailLanguage(emailId, 'fr').catch(() => undefined);
+      await api!
+        .updateDesignStudioEmailLanguage(emailId, 'fr', { content: { subject: 'Salut' } })
+        .catch(() => undefined);
+      await api!.deleteDesignStudioEmailLanguage(emailId, 'fr').catch(() => undefined);
+
       await api!.deleteDesignStudioEmail(emailId).catch(() => undefined);
     }
 
@@ -343,6 +355,30 @@ liveTest('design studio folder + email create -> read -> update -> delete round-
   }
 
   t.truthy(folder);
+});
+
+liveTest('listDesignStudioComponents resolves', async (t) => {
+  const result = (await api!.listDesignStudioComponents({ limit: 5 })) as { components?: unknown };
+  t.true('components' in result);
+});
+
+liveTest('design studio component create -> read -> update -> delete round-trip', async (t) => {
+  const created = (await api!
+    .createDesignStudioComponent({
+      name: `sdk-live-component-${customerId}`,
+      tag: `sdk-live-${customerId}`,
+      content: '<div>hi</div>',
+    })
+    .catch(() => undefined)) as { component?: { id?: string } } | undefined;
+  const componentId = created?.component?.id;
+
+  if (componentId) {
+    await api!.getDesignStudioComponent(componentId).catch(() => undefined);
+    await api!.updateDesignStudioComponent(componentId, { content: '<div>updated</div>' }).catch(() => undefined);
+    await api!.deleteDesignStudioComponent(componentId).catch(() => undefined);
+  }
+
+  t.pass();
 });
 
 liveTest('track records an event on the profile', async (t) => {

--- a/test/request.ts
+++ b/test/request.ts
@@ -159,6 +159,53 @@ test.serial('#options does not allow defaults.headers to clobber the standard he
   t.is((result.headers as Record<string, string>)['User-Agent'], `Customer.io Node Client/${PACKAGE_VERSION}`);
 });
 
+test.serial(
+  '#formOptions omits Content-Type (fetch adds the multipart boundary) and keeps the standard headers',
+  (t) => {
+    const form = new FormData();
+    form.append('file', new Blob([Buffer.from('x')], { type: 'image/png' }), 'x.png');
+
+    const result = t.context.req.formOptions(uri, 'POST', form);
+
+    t.is(result.method, 'POST');
+    t.is(result.uri, uri);
+    t.is(result.body, form);
+    const headers = result.headers as Record<string, string>;
+    t.false('Content-Type' in headers);
+    t.false('Content-Length' in headers);
+    t.is(headers.Authorization, trackAuth);
+    t.is(headers['User-Agent'], `Customer.io Node Client/${PACKAGE_VERSION}`);
+  },
+);
+
+test.serial('#formOptions merges custom headers but drops any Content-Type from defaults.headers', (t) => {
+  const req = new Request(
+    { siteid, apikey },
+    { headers: { 'X-Strict-Mode': '1', 'Content-Type': 'application/json' } },
+  );
+  const result = req.formOptions(uri, 'POST', new FormData());
+  const headers = result.headers as Record<string, string>;
+  t.is(headers['X-Strict-Mode'], '1');
+  t.false('Content-Type' in headers);
+  t.is(headers.Authorization, trackAuth);
+});
+
+test.serial('#postForm sends the FormData body to fetch without a JSON content type', async (t) => {
+  const form = new FormData();
+  form.append('file', new Blob([Buffer.from('hello')], { type: 'image/png' }), 'hello.png');
+  createMockRequest(t.context.fetchStub, 200, { asset: { id: 1 } });
+
+  const res = await t.context.req.postForm(uri, form);
+
+  const call = t.context.fetchStub.getCall(0);
+  t.is(call.args[0], uri);
+  const init = call.args[1] as RequestInit;
+  t.is(init.method, 'POST');
+  t.is(init.body, form);
+  t.false('Content-Type' in (init.headers as Record<string, string>));
+  t.deepEqual(res, { asset: { id: 1 } });
+});
+
 test.serial('#handler returns a promise', (t) => {
   createMockRequest(t.context.fetchStub, 200);
   const promise = t.context.req.handler(putOptions);
@@ -235,10 +282,12 @@ test.serial('#handler does not let defaults override the SDK-owned fetch fields'
   // `method`/`body`/`redirect`/`signal` are owned by the SDK. Even if a caller
   // smuggles them in via defaults (they're omitted from the type), the
   // transport's own values must win.
-  const req = new Request(
-    { siteid, apikey },
-    { timeout: 5000, redirect: 'follow', method: 'PATCH', body: 'nope' } as never,
-  );
+  const req = new Request({ siteid, apikey }, {
+    timeout: 5000,
+    redirect: 'follow',
+    method: 'PATCH',
+    body: 'nope',
+  } as never);
   createMockRequest(t.context.fetchStub, 200, {});
 
   await req.handler(req.options(uri, 'GET'));


### PR DESCRIPTION
Another set of the App API backfill on top of #239 which adds 5 email-translation (language) methods and 5 component methods:

| Method | Endpoint |
| --- | --- |
| `listDesignStudioEmailLanguages` | `GET /v1/design_studio/emails/{id}/languages` |
| `createDesignStudioEmailLanguage` | `POST /v1/design_studio/emails/{id}/languages` |
| `getDesignStudioEmailLanguage` | `GET /v1/design_studio/emails/{id}/languages/{language}` |
| `updateDesignStudioEmailLanguage` | `PUT …/languages/{language}` (204) |
| `deleteDesignStudioEmailLanguage` | `DELETE …/languages/{language}` (204) |
| `listDesignStudioComponents` | `GET /v1/design_studio/components` |
| `createDesignStudioComponent` | `POST /v1/design_studio/components` |
| `getDesignStudioComponent` | `GET /v1/design_studio/components/{id}` |
| `updateDesignStudioComponent` | `PUT /v1/design_studio/components/{id}` (204) |
| `deleteDesignStudioComponent` | `DELETE /v1/design_studio/components/{id}` (204) |

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large additive API surface plus shared HTTP transport changes for multipart; behavior is well-tested but affects all clients using `Request` body typing.
> 
> **Overview**
> Extends the App API client with **Design Studio email translations** (list/create/get/update/delete per language), **reusable components** (full CRUD plus list with optional `tag` filter), and a new **Assets** surface for files and folders (list/upload/get/update/delete).
> 
> **Assets uploads** go through new `Request.postForm` / `formOptions` multipart handling so `fetch` can set the boundary; `createAsset` builds `FormData` and **derives MIME types** from filename (or explicit/`Blob` type) so uploads are not sent as `application/octet-stream`. Typed inputs and matching **docs** (`docs/app.md`), unit tests, and live integration round-trips are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a703381271a2ef1997053883128e76653c0f62af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->