### PR TITLE
feat: add App API Assets methods + multipart upload

### DIFF
--- a/docs/app.md
+++ b/docs/app.md
@@ -1616,3 +1616,152 @@ api.deleteDesignStudioComponent("3b2…");
 #### Options
 
 - **componentId**: The component's UUID (required)
+
+## Assets
+
+Manage uploaded files (images, PDFs) and the folders that organize them. Asset and folder ids are **integers**.
+
+The list endpoints share folder filtering and page-based pagination:
+
+- **parentFolderId**: Only list items within this folder id (omit for all/root)
+- **directDescendantsOnly**: When `true`, return only direct children rather than the whole subtree
+- **page**: 1-based page number (default 1)
+- **limit**: page size, 1–10000 (default 1000)
+
+On file and folder updates, `parent_folder_id` is tri-state: **omit** to keep the current parent, pass `null` to move to the root, or pass a folder id to move it.
+
+### api.listAssets(options)
+
+List uploaded files.
+
+```javascript
+api.listAssets({ parentFolderId: 5, limit: 50 });
+```
+
+#### Options
+
+- **options**: Object (optional) — `parentFolderId`, `directDescendantsOnly`, `page`, `limit`
+
+### api.createAsset(file)
+
+Upload a file (`multipart/form-data`). The API accepts images (`image/bmp`, `image/jpeg`, `image/jpg`, `image/png`, `image/gif`) and `application/pdf`, up to 2 MB (images max 4096px per side).
+
+```javascript
+const fs = require("fs");
+
+api.createAsset({
+  data: fs.readFileSync("logo.png"),
+  filename: "logo.png",
+  contentType: "image/png",
+  parentFolderId: 5,
+});
+```
+
+#### Options
+
+- **file**: The upload definition
+  - _data_: File contents — any `Buffer`/`Blob`-compatible value (required)
+  - _filename_: Filename; also the default asset name and the source of the derived content type (required)
+  - _contentType_: MIME type of the upload; when omitted the API derives it from the filename
+  - _name_: Asset name; defaults to `filename`
+  - _parentFolderId_: Parent folder id; omit for the root
+
+### api.getAsset(assetId)
+
+Get a single file.
+
+```javascript
+api.getAsset(42);
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+
+### api.updateAsset(assetId, updates)
+
+Rename and/or move a file. At least one field must be provided; the file bytes cannot be changed. Returns no content on success.
+
+```javascript
+api.updateAsset(42, { name: "renamed.png", parent_folder_id: null });
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+- **updates**: Object with any of `name`, `parent_folder_id`
+
+### api.deleteAsset(assetId)
+
+Delete a file. Returns no content on success.
+
+```javascript
+api.deleteAsset(42);
+```
+
+#### Options
+
+- **assetId**: The asset's numeric id (required)
+
+### api.listAssetFolders(options)
+
+List asset folders.
+
+```javascript
+api.listAssetFolders({ parentFolderId: 5, limit: 50 });
+```
+
+#### Options
+
+- **options**: Object (optional) — `parentFolderId`, `directDescendantsOnly`, `page`, `limit`
+
+### api.createAssetFolder(folder)
+
+Create an asset folder.
+
+```javascript
+api.createAssetFolder({ name: "Product images", parent_folder_id: 5 });
+```
+
+#### Options
+
+- **folder**: The folder definition
+  - _name_: The folder's display name (required)
+  - _parent_folder_id_: Parent folder id; omit for the root
+
+### api.getAssetFolder(folderId)
+
+Get a single asset folder.
+
+```javascript
+api.getAssetFolder(5);
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)
+
+### api.updateAssetFolder(folderId, updates)
+
+Rename and/or move a folder. At least one field must be provided. Returns no content on success.
+
+```javascript
+api.updateAssetFolder(5, { name: "Renamed", parent_folder_id: null });
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)
+- **updates**: Object with any of `name`, `parent_folder_id`
+
+### api.deleteAssetFolder(folderId)
+
+Delete an asset folder. The folder must be empty.
+
+```javascript
+api.deleteAssetFolder(5);
+```
+
+#### Options
+
+- **folderId**: The folder's numeric id (required)

--- a/docs/app.md
+++ b/docs/app.md
@@ -1661,8 +1661,8 @@ api.createAsset({
 
 - **file**: The upload definition
   - _data_: File contents — any `Buffer`/`Blob`-compatible value (required)
-  - _filename_: Filename; also the default asset name and the source of the derived content type (required)
-  - _contentType_: MIME type of the upload; when omitted the API derives it from the filename
+  - _filename_: Filename; also the default asset name and, when `contentType` is omitted, the source for the derived content type (required)
+  - _contentType_: MIME type of the upload; when omitted the SDK derives it from the filename extension (`.bmp`, `.jpg`/`.jpeg`, `.png`, `.gif`, `.pdf`)
   - _name_: Asset name; defaults to `filename`
   - _parentFolderId_: Parent folder id; omit for the root
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -406,6 +406,65 @@ export type DesignStudioComponentUpdate = {
   content?: string;
 };
 
+/** Filters and pagination shared by the asset list endpoints (page-based). */
+export type AssetListOptions = {
+  /** Only list assets directly within this folder id (omit for all/root). */
+  parentFolderId?: number;
+  /** When `true`, return only direct children rather than the whole subtree. */
+  directDescendantsOnly?: boolean;
+  /** 1-based page number. Defaults to 1. */
+  page?: number;
+  /** Page size, 1–10000. Defaults to 1000. */
+  limit?: number;
+};
+
+/**
+ * Definition for uploading a file via {@link APIClient.createAsset}.
+ *
+ * The API accepts images (`image/bmp`, `image/jpeg`, `image/jpg`, `image/png`,
+ * `image/gif`) and `application/pdf`, up to 2 MB (images max 4096px per side).
+ */
+export type CreateAssetInput = {
+  /** File contents. Any `Buffer.from`/`Blob`-compatible value (Buffer, Uint8Array, ArrayBuffer, string). */
+  data: any;
+  /** Filename — also the multipart filename, the default asset `name`, and the source for the derived content type. */
+  filename: string;
+  /** MIME type of the upload. When omitted, the API derives it from `filename`. */
+  contentType?: string;
+  /** Asset name. Defaults to `filename`. */
+  name?: string;
+  /** Parent folder id. Omit for the root. */
+  parentFolderId?: number;
+};
+
+/**
+ * Fields for updating an asset via {@link APIClient.updateAsset}. At least one must be provided;
+ * file bytes cannot be changed. `parent_folder_id` is tri-state: omit to keep the current parent,
+ * `null` to move to the root, or a folder id to move it into that folder.
+ */
+export type AssetUpdate = {
+  name?: string;
+  parent_folder_id?: number | null;
+};
+
+/** Definition for creating an asset folder via {@link APIClient.createAssetFolder}. */
+export type AssetFolderInput = {
+  /** The folder's display name (required). */
+  name: string;
+  /** Parent folder id. Omit for the root. */
+  parent_folder_id?: number;
+};
+
+/**
+ * Fields for updating an asset folder via {@link APIClient.updateAssetFolder}. At least one must
+ * be provided. `parent_folder_id` is tri-state: omit to keep the current parent, `null` to move to
+ * the root, or a folder id to move it into that folder.
+ */
+export type AssetFolderUpdate = {
+  name?: string;
+  parent_folder_id?: number | null;
+};
+
 type APIDefaults = RequestDefaults & { region: Region; url?: string; retry?: Partial<RetryOptions> };
 
 type Recipients = Record<string, unknown>;
@@ -2900,6 +2959,195 @@ export class APIClient {
     }
 
     return this.request.destroy(`${this.apiRoot}/design_studio/components/${encodeURIComponent(componentId)}`);
+  }
+
+  /**
+   * List uploaded assets (files).
+   *
+   * @param options Optional folder filter and pagination. See {@link AssetListOptions}.
+   * @returns The parsed JSON response body (`{ assets: [...], meta }`).
+   */
+  listAssets(options: AssetListOptions = {}) {
+    const query = buildQueryString({
+      parent_folder_id: options.parentFolderId,
+      direct_descendants_only: options.directDescendantsOnly,
+      page: options.page,
+      limit: options.limit,
+    });
+
+    return this.request.get(`${this.apiRoot}/assets${query}`);
+  }
+
+  /**
+   * Upload a file asset (`multipart/form-data`).
+   *
+   * @param file The file to upload. `data` and `filename` are required. See {@link CreateAssetInput}.
+   * @returns The parsed JSON response body (`{ asset: {...} }`).
+   * @throws {MissingParamError} If `file` is missing/not an object, or `file.data`/`file.filename` is missing.
+   */
+  createAsset(file: CreateAssetInput) {
+    if (file == null || typeof file !== 'object') {
+      throw new MissingParamError('file');
+    }
+
+    if (file.data == null) {
+      throw new MissingParamError('file.data');
+    }
+
+    if (isEmpty(file.filename)) {
+      throw new MissingParamError('file.filename');
+    }
+
+    const form = new FormData();
+    const blob = file.contentType ? new Blob([file.data], { type: file.contentType }) : new Blob([file.data]);
+    form.append('file', blob, file.filename);
+
+    if (file.name !== undefined) {
+      form.append('name', file.name);
+    }
+
+    if (file.parentFolderId !== undefined) {
+      form.append('parent_folder_id', String(file.parentFolderId));
+    }
+
+    return this.request.postForm(`${this.apiRoot}/assets/files`, form);
+  }
+
+  /**
+   * Get a single asset (file).
+   *
+   * @param assetId The asset's numeric id.
+   * @returns The parsed JSON response body (`{ asset: {...} }`).
+   * @throws {MissingParamError} If `assetId` is empty.
+   */
+  getAsset(assetId: string | number) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    return this.request.get(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`);
+  }
+
+  /**
+   * Update an asset's name and/or parent folder. At least one field must be provided;
+   * the file bytes cannot be changed.
+   *
+   * @param assetId The asset's numeric id.
+   * @param updates The fields to change. See {@link AssetUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `assetId` is empty or `updates` is missing/not an object.
+   */
+  updateAsset(assetId: string | number, updates: AssetUpdate) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`, updates);
+  }
+
+  /**
+   * Delete an asset (file).
+   *
+   * @param assetId The asset's numeric id.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `assetId` is empty.
+   */
+  deleteAsset(assetId: string | number) {
+    if (isEmpty(assetId)) {
+      throw new MissingParamError('assetId');
+    }
+
+    return this.request.destroy(`${this.apiRoot}/assets/files/${encodeURIComponent(assetId)}`);
+  }
+
+  /**
+   * List asset folders.
+   *
+   * @param options Optional folder filter and pagination. See {@link AssetListOptions}.
+   * @returns The parsed JSON response body (`{ folders: [...], meta }`).
+   */
+  listAssetFolders(options: AssetListOptions = {}) {
+    const query = buildQueryString({
+      parent_folder_id: options.parentFolderId,
+      direct_descendants_only: options.directDescendantsOnly,
+      page: options.page,
+      limit: options.limit,
+    });
+
+    return this.request.get(`${this.apiRoot}/assets/folders${query}`);
+  }
+
+  /**
+   * Create an asset folder.
+   *
+   * @param folder The folder definition. `name` is required. See {@link AssetFolderInput}.
+   * @returns The parsed JSON response body (`{ folder: {...} }`).
+   * @throws {MissingParamError} If `folder` is missing/not an object, or `folder.name` is empty.
+   */
+  createAssetFolder(folder: AssetFolderInput) {
+    if (folder == null || typeof folder !== 'object') {
+      throw new MissingParamError('folder');
+    }
+
+    if (isEmpty(folder.name)) {
+      throw new MissingParamError('folder.name');
+    }
+
+    return this.request.post(`${this.apiRoot}/assets/folders`, folder);
+  }
+
+  /**
+   * Get a single asset folder.
+   *
+   * @param folderId The folder's numeric id.
+   * @returns The parsed JSON response body (`{ folder: {...} }`).
+   * @throws {MissingParamError} If `folderId` is empty.
+   */
+  getAssetFolder(folderId: string | number) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    return this.request.get(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`);
+  }
+
+  /**
+   * Update an asset folder. At least one field must be provided.
+   *
+   * @param folderId The folder's numeric id.
+   * @param updates The fields to change. See {@link AssetFolderUpdate}.
+   * @returns The parsed JSON response body (empty on success — the API returns 204).
+   * @throws {MissingParamError} If `folderId` is empty or `updates` is missing/not an object.
+   */
+  updateAssetFolder(folderId: string | number, updates: AssetFolderUpdate) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    if (updates == null || typeof updates !== 'object') {
+      throw new MissingParamError('updates');
+    }
+
+    return this.request.put(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`, updates);
+  }
+
+  /**
+   * Delete an asset folder. The folder must be empty.
+   *
+   * @param folderId The folder's numeric id.
+   * @returns The parsed JSON response body.
+   * @throws {MissingParamError} If `folderId` is empty.
+   */
+  deleteAssetFolder(folderId: string | number) {
+    if (isEmpty(folderId)) {
+      throw new MissingParamError('folderId');
+    }
+
+    return this.request.destroy(`${this.apiRoot}/assets/folders/${encodeURIComponent(folderId)}`);
   }
 }
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -427,14 +427,42 @@ export type AssetListOptions = {
 export type CreateAssetInput = {
   /** File contents. A `Uint8Array` (a `Buffer`, e.g. from `fs.readFileSync`, is one), `ArrayBuffer`, `Blob`, or `string`. */
   data: Uint8Array | ArrayBuffer | Blob | string;
-  /** Filename — also the multipart filename, the default asset `name`, and the source for the derived content type. */
+  /** Filename — also the multipart filename, the default asset `name`, and (when `contentType` is omitted) the source for the derived content type. */
   filename: string;
-  /** MIME type of the upload. When omitted, the API derives it from `filename`. */
+  /**
+   * MIME type of the upload. When omitted, the SDK derives it from the `filename` extension
+   * for the accepted image/PDF types (`.bmp`, `.jpg`/`.jpeg`, `.png`, `.gif`, `.pdf`).
+   */
   contentType?: string;
   /** Asset name. Defaults to `filename`. */
   name?: string;
   /** Parent folder id. Omit for the root. */
   parentFolderId?: number;
+};
+
+/**
+ * Accepted upload extensions mapped to their MIME type. Used to set the multipart
+ * part's `Content-Type` client-side when the caller omits `contentType`: an untyped
+ * `Blob` is serialized as `application/octet-stream`, which the Assets API rejects,
+ * and the API's own extension fallback only runs when the part carries no type at all.
+ */
+const ASSET_CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  bmp: 'image/bmp',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  gif: 'image/gif',
+  pdf: 'application/pdf',
+};
+
+/** Derive an accepted asset MIME type from a filename's extension, or `undefined` if unrecognized. */
+const assetContentTypeForFilename = (filename: string): string | undefined => {
+  const dot = filename.lastIndexOf('.');
+  if (dot < 0) {
+    return undefined;
+  }
+
+  return ASSET_CONTENT_TYPE_BY_EXTENSION[filename.slice(dot + 1).toLowerCase()];
 };
 
 /**
@@ -2998,8 +3026,18 @@ export class APIClient {
       throw new MissingParamError('file.filename');
     }
 
+    // Set the part's Content-Type explicitly. An untyped Blob is serialized as
+    // `application/octet-stream`, which the API rejects, so resolve a type from
+    // (in order) an explicit `contentType`, the filename extension, or the type
+    // already on `data` when it is a Blob. An empty-string `contentType` is
+    // treated as absent so it still falls through to derivation.
+    const explicitType = isEmpty(file.contentType) ? undefined : file.contentType;
+    const contentType =
+      explicitType ??
+      assetContentTypeForFilename(file.filename) ??
+      (file.data instanceof Blob && file.data.type ? file.data.type : undefined);
     const form = new FormData();
-    const blob = file.contentType ? new Blob([file.data], { type: file.contentType }) : new Blob([file.data]);
+    const blob = contentType ? new Blob([file.data], { type: contentType }) : new Blob([file.data]);
     form.append('file', blob, file.filename);
 
     if (file.name !== undefined) {

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -425,8 +425,8 @@ export type AssetListOptions = {
  * `image/gif`) and `application/pdf`, up to 2 MB (images max 4096px per side).
  */
 export type CreateAssetInput = {
-  /** File contents. Any `Buffer.from`/`Blob`-compatible value (Buffer, Uint8Array, ArrayBuffer, string). */
-  data: any;
+  /** File contents. A `Uint8Array` (a `Buffer`, e.g. from `fs.readFileSync`, is one), `ArrayBuffer`, `Blob`, or `string`. */
+  data: Uint8Array | ArrayBuffer | Blob | string;
   /** Filename — also the multipart filename, the default asset `name`, and the source for the derived content type. */
   filename: string;
   /** MIME type of the upload. When omitted, the API derives it from `filename`. */

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -35,7 +35,7 @@ export interface RequestHandlerOptions {
   method: string;
   uri: string;
   headers: Record<string, string | number>;
-  body?: string | null;
+  body?: string | FormData | null;
 }
 export interface PushRequestData {
   delivery_id?: string;
@@ -150,6 +150,23 @@ export default class CIORequest {
     }
 
     return { method, uri, headers, body };
+  }
+
+  /**
+   * Build request options for a `multipart/form-data` upload. Unlike
+   * {@link options}, the `Content-Type` is deliberately left unset so `fetch`
+   * adds it with the correct multipart boundary, and no `Content-Length` is
+   * computed (the runtime streams the body).
+   */
+  formOptions(uri: string, method: string, form: FormData): RequestHandlerOptions {
+    const customHeaders = (this.defaults.headers ?? {}) as Record<string, string | number>;
+    const headers: Record<string, string | number> = {
+      ...customHeaders,
+      Authorization: this.auth,
+      'User-Agent': `Customer.io Node Client/${version}`,
+    };
+
+    return { method, uri, headers, body: form };
   }
 
   private async execute({ uri, body, method, headers }: RequestHandlerOptions): Promise<Record<string, any>> {
@@ -339,5 +356,9 @@ export default class CIORequest {
 
   post(uri: string, data: RequestData = {}) {
     return this.handler(this.options(uri, 'POST', data));
+  }
+
+  postForm(uri: string, form: FormData) {
+    return this.handler(this.formOptions(uri, 'POST', form));
   }
 }

--- a/lib/request.ts
+++ b/lib/request.ts
@@ -160,11 +160,19 @@ export default class CIORequest {
    */
   formOptions(uri: string, method: string, form: FormData): RequestHandlerOptions {
     const customHeaders = (this.defaults.headers ?? {}) as Record<string, string | number>;
-    const headers: Record<string, string | number> = {
-      ...customHeaders,
-      Authorization: this.auth,
-      'User-Agent': `Customer.io Node Client/${version}`,
-    };
+    const headers: Record<string, string | number> = {};
+
+    // Merge caller headers, but never a Content-Type: multipart uploads rely on
+    // `fetch` setting `multipart/form-data` with a boundary, so a stray
+    // Content-Type from `defaults.headers` would corrupt the request body.
+    for (const [key, value] of Object.entries(customHeaders)) {
+      if (key.toLowerCase() !== 'content-type') {
+        headers[key] = value;
+      }
+    }
+
+    headers.Authorization = this.auth;
+    headers['User-Agent'] = `Customer.io Node Client/${version}`;
 
     return { method, uri, headers, body: form };
   }

--- a/test/api.ts
+++ b/test/api.ts
@@ -1969,3 +1969,120 @@ test('#deleteDesignStudioComponent: deletes a component and validates', (t) => {
   t.context.client.deleteDesignStudioComponent('comp-1');
   t.true(destroy.calledWith(`${API}/design_studio/components/comp-1`));
 });
+
+// Assets: files
+
+test('#listAssets: gets the assets endpoint with no query by default', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssets();
+  t.true(get.calledWith(`${API}/assets`));
+});
+
+test('#listAssets: forwards folder filter and pagination', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssets({ parentFolderId: 5, directDescendantsOnly: true, page: 2, limit: 50 });
+  t.true(get.calledWith(`${API}/assets?parent_folder_id=5&direct_descendants_only=true&page=2&limit=50`));
+});
+
+test('#createAsset: uploads a multipart form with all fields', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.throws(() => (t.context.client.createAsset as any)(null), { message: 'file is required' });
+  t.throws(() => (t.context.client.createAsset as any)({ filename: 'a.png' }), { message: 'file.data is required' });
+  t.throws(() => (t.context.client.createAsset as any)({ data: Buffer.from('x') }), {
+    message: 'file.filename is required',
+  });
+
+  t.context.client.createAsset({
+    data: Buffer.from('hello'),
+    filename: 'hello.png',
+    contentType: 'image/png',
+    name: 'Hello',
+    parentFolderId: 7,
+  });
+
+  t.true(postForm.calledOnce);
+  const [uri, form] = postForm.getCall(0).args as [string, FormData];
+  t.is(uri, `${API}/assets/files`);
+  const filePart = form.get('file') as any;
+  t.is(filePart.type, 'image/png');
+  t.is(filePart.name, 'hello.png');
+  t.is(form.get('name'), 'Hello');
+  t.is(form.get('parent_folder_id'), '7');
+});
+
+test('#createAsset: omits optional fields and derives content type when unset', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.png' });
+
+  const form = postForm.getCall(0).args[1] as FormData;
+  const filePart = form.get('file') as any;
+  t.is(filePart.type, '');
+  t.is(form.get('name'), null);
+  t.is(form.get('parent_folder_id'), null);
+});
+
+test('#getAsset: gets a single asset and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getAsset(''), { message: 'assetId is required' });
+  t.context.client.getAsset(3);
+  t.true(get.calledWith(`${API}/assets/files/3`));
+});
+
+test('#updateAsset: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateAsset('', { name: 'x' }), { message: 'assetId is required' });
+  t.throws(() => (t.context.client.updateAsset as any)(3, null), { message: 'updates is required' });
+  t.context.client.updateAsset(3, { name: 'Renamed', parent_folder_id: null });
+  t.true(put.calledWith(`${API}/assets/files/3`, { name: 'Renamed', parent_folder_id: null }));
+});
+
+test('#deleteAsset: deletes an asset and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteAsset(''), { message: 'assetId is required' });
+  t.context.client.deleteAsset(3);
+  t.true(destroy.calledWith(`${API}/assets/files/3`));
+});
+
+// Assets: folders
+
+test('#listAssetFolders: gets the folders endpoint with no query by default', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssetFolders();
+  t.true(get.calledWith(`${API}/assets/folders`));
+});
+
+test('#listAssetFolders: forwards folder filter and pagination', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.context.client.listAssetFolders({ parentFolderId: 5, limit: 10 });
+  t.true(get.calledWith(`${API}/assets/folders?parent_folder_id=5&limit=10`));
+});
+
+test('#createAssetFolder: posts the folder body and validates', (t) => {
+  const post = sinon.stub(t.context.client.request, 'post');
+  t.throws(() => (t.context.client.createAssetFolder as any)(null), { message: 'folder is required' });
+  t.throws(() => (t.context.client.createAssetFolder as any)({}), { message: 'folder.name is required' });
+  t.context.client.createAssetFolder({ name: 'Images', parent_folder_id: 2 });
+  t.true(post.calledWith(`${API}/assets/folders`, { name: 'Images', parent_folder_id: 2 }));
+});
+
+test('#getAssetFolder: gets a single folder and validates', (t) => {
+  const get = sinon.stub(t.context.client.request, 'get');
+  t.throws(() => t.context.client.getAssetFolder(''), { message: 'folderId is required' });
+  t.context.client.getAssetFolder(2);
+  t.true(get.calledWith(`${API}/assets/folders/2`));
+});
+
+test('#updateAssetFolder: puts the updates and validates', (t) => {
+  const put = sinon.stub(t.context.client.request, 'put');
+  t.throws(() => t.context.client.updateAssetFolder('', { name: 'x' }), { message: 'folderId is required' });
+  t.throws(() => (t.context.client.updateAssetFolder as any)(2, null), { message: 'updates is required' });
+  t.context.client.updateAssetFolder(2, { name: 'Renamed', parent_folder_id: null });
+  t.true(put.calledWith(`${API}/assets/folders/2`, { name: 'Renamed', parent_folder_id: null }));
+});
+
+test('#deleteAssetFolder: deletes a folder and validates', (t) => {
+  const destroy = sinon.stub(t.context.client.request, 'destroy');
+  t.throws(() => t.context.client.deleteAssetFolder(''), { message: 'folderId is required' });
+  t.context.client.deleteAssetFolder(2);
+  t.true(destroy.calledWith(`${API}/assets/folders/2`));
+});

--- a/test/api.ts
+++ b/test/api.ts
@@ -2010,15 +2010,40 @@ test('#createAsset: uploads a multipart form with all fields', (t) => {
   t.is(form.get('parent_folder_id'), '7');
 });
 
-test('#createAsset: omits optional fields and derives content type when unset', (t) => {
+test('#createAsset: derives the content type from the filename when unset', (t) => {
   const postForm = sinon.stub(t.context.client.request, 'postForm');
-  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.png' });
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.PNG' });
 
   const form = postForm.getCall(0).args[1] as FormData;
   const filePart = form.get('file') as any;
-  t.is(filePart.type, '');
+  // Derived from the (case-insensitive) extension, so the wire part is not application/octet-stream.
+  t.is(filePart.type, 'image/png');
   t.is(form.get('name'), null);
   t.is(form.get('parent_folder_id'), null);
+});
+
+test('#createAsset: treats an empty contentType as absent and derives from the filename', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'hello.png', contentType: '' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, 'image/png');
+});
+
+test('#createAsset: preserves the type of a Blob passed as data when nothing else resolves', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: new Blob([Buffer.from('hello')], { type: 'image/gif' }), filename: 'noext' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, 'image/gif');
+});
+
+test('#createAsset: leaves the content type unset for an unrecognized extension', (t) => {
+  const postForm = sinon.stub(t.context.client.request, 'postForm');
+  t.context.client.createAsset({ data: Buffer.from('hello'), filename: 'notes' });
+
+  const filePart = (postForm.getCall(0).args[1] as FormData).get('file') as any;
+  t.is(filePart.type, '');
 });
 
 test('#getAsset: gets a single asset and validates', (t) => {

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -381,6 +381,50 @@ liveTest('design studio component create -> read -> update -> delete round-trip'
   t.pass();
 });
 
+liveTest('listAssets resolves', async (t) => {
+  const result = (await api!.listAssets({ limit: 5 })) as { assets?: unknown };
+  t.true('assets' in result);
+});
+
+liveTest('listAssetFolders resolves', async (t) => {
+  const result = (await api!.listAssetFolders({ limit: 5 })) as { folders?: unknown };
+  t.true('folders' in result);
+});
+
+liveTest('asset folder + file create -> read -> update -> delete round-trip', async (t) => {
+  // A minimal valid 1x1 PNG — the backend validates that uploads are real images.
+  const pngBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==';
+  const pngBytes = Buffer.from(pngBase64, 'base64');
+
+  const folder = (await api!.createAssetFolder({ name: `sdk-live-assets-${customerId}` }).catch(() => undefined)) as
+    | { folder?: { id?: number } }
+    | undefined;
+  const folderId = folder?.folder?.id;
+
+  const uploaded = (await api!
+    .createAsset({
+      data: pngBytes,
+      filename: `sdk-live-${customerId}.png`,
+      contentType: 'image/png',
+      parentFolderId: folderId,
+    })
+    .catch(() => undefined)) as { asset?: { id?: number } } | undefined;
+  const assetId = uploaded?.asset?.id;
+
+  if (assetId !== undefined) {
+    await api!.getAsset(assetId).catch(() => undefined);
+    await api!.updateAsset(assetId, { name: `sdk-live-${customerId}-renamed.png` }).catch(() => undefined);
+    await api!.deleteAsset(assetId).catch(() => undefined);
+  }
+
+  if (folderId !== undefined) {
+    await api!.getAssetFolder(folderId).catch(() => undefined);
+    await api!.deleteAssetFolder(folderId).catch(() => undefined);
+  }
+
+  t.pass();
+});
+
 liveTest('track records an event on the profile', async (t) => {
   await track!.track(customerId, { name: 'sdk_live_event', data: { run: customerId } });
   t.pass();

--- a/test/integration/live.ts
+++ b/test/integration/live.ts
@@ -404,8 +404,8 @@ liveTest('asset folder + file create -> read -> update -> delete round-trip', as
   const uploaded = (await api!
     .createAsset({
       data: pngBytes,
+      // No contentType: exercises the filename-extension derivation end-to-end.
       filename: `sdk-live-${customerId}.png`,
-      contentType: 'image/png',
       parentFolderId: folderId,
     })
     .catch(() => undefined)) as { asset?: { id?: number } } | undefined;

--- a/test/request.ts
+++ b/test/request.ts
@@ -159,6 +159,47 @@ test.serial('#options does not allow defaults.headers to clobber the standard he
   t.is((result.headers as Record<string, string>)['User-Agent'], `Customer.io Node Client/${PACKAGE_VERSION}`);
 });
 
+test.serial(
+  '#formOptions omits Content-Type (fetch adds the multipart boundary) and keeps the standard headers',
+  (t) => {
+    const form = new FormData();
+    form.append('file', new Blob([Buffer.from('x')], { type: 'image/png' }), 'x.png');
+
+    const result = t.context.req.formOptions(uri, 'POST', form);
+
+    t.is(result.method, 'POST');
+    t.is(result.uri, uri);
+    t.is(result.body, form);
+    const headers = result.headers as Record<string, string>;
+    t.false('Content-Type' in headers);
+    t.false('Content-Length' in headers);
+    t.is(headers.Authorization, trackAuth);
+    t.is(headers['User-Agent'], `Customer.io Node Client/${PACKAGE_VERSION}`);
+  },
+);
+
+test.serial('#formOptions merges custom headers from defaults.headers', (t) => {
+  const req = new Request({ siteid, apikey }, { headers: { 'X-Strict-Mode': '1' } });
+  const result = req.formOptions(uri, 'POST', new FormData());
+  t.is((result.headers as Record<string, string>)['X-Strict-Mode'], '1');
+});
+
+test.serial('#postForm sends the FormData body to fetch without a JSON content type', async (t) => {
+  const form = new FormData();
+  form.append('file', new Blob([Buffer.from('hello')], { type: 'image/png' }), 'hello.png');
+  createMockRequest(t.context.fetchStub, 200, { asset: { id: 1 } });
+
+  const res = await t.context.req.postForm(uri, form);
+
+  const call = t.context.fetchStub.getCall(0);
+  t.is(call.args[0], uri);
+  const init = call.args[1] as RequestInit;
+  t.is(init.method, 'POST');
+  t.is(init.body, form);
+  t.false('Content-Type' in (init.headers as Record<string, string>));
+  t.deepEqual(res, { asset: { id: 1 } });
+});
+
 test.serial('#handler returns a promise', (t) => {
   createMockRequest(t.context.fetchStub, 200);
   const promise = t.context.req.handler(putOptions);
@@ -235,10 +276,12 @@ test.serial('#handler does not let defaults override the SDK-owned fetch fields'
   // `method`/`body`/`redirect`/`signal` are owned by the SDK. Even if a caller
   // smuggles them in via defaults (they're omitted from the type), the
   // transport's own values must win.
-  const req = new Request(
-    { siteid, apikey },
-    { timeout: 5000, redirect: 'follow', method: 'PATCH', body: 'nope' } as never,
-  );
+  const req = new Request({ siteid, apikey }, {
+    timeout: 5000,
+    redirect: 'follow',
+    method: 'PATCH',
+    body: 'nope',
+  } as never);
   createMockRequest(t.context.fetchStub, 200, {});
 
   await req.handler(req.options(uri, 'GET'));

--- a/test/request.ts
+++ b/test/request.ts
@@ -178,10 +178,16 @@ test.serial(
   },
 );
 
-test.serial('#formOptions merges custom headers from defaults.headers', (t) => {
-  const req = new Request({ siteid, apikey }, { headers: { 'X-Strict-Mode': '1' } });
+test.serial('#formOptions merges custom headers but drops any Content-Type from defaults.headers', (t) => {
+  const req = new Request(
+    { siteid, apikey },
+    { headers: { 'X-Strict-Mode': '1', 'Content-Type': 'application/json' } },
+  );
   const result = req.formOptions(uri, 'POST', new FormData());
-  t.is((result.headers as Record<string, string>)['X-Strict-Mode'], '1');
+  const headers = result.headers as Record<string, string>;
+  t.is(headers['X-Strict-Mode'], '1');
+  t.false('Content-Type' in headers);
+  t.is(headers.Authorization, trackAuth);
 });
 
 test.serial('#postForm sends the FormData body to fetch without a JSON content type', async (t) => {


### PR DESCRIPTION
Another set of the App API backfill on top of #240 which adds 10 methods plus a `multipart/form-data` upload path in the request layer.

| Method | Endpoint |
| --- | --- |
| `listAssets` | `GET /v1/assets` |
| `createAsset` | `POST /v1/assets/files` (multipart upload) |
| `getAsset` | `GET /v1/assets/files/{id}` |
| `updateAsset` | `PUT /v1/assets/files/{id}` (204) |
| `deleteAsset` | `DELETE /v1/assets/files/{id}` (204) |
| `listAssetFolders` | `GET /v1/assets/folders` |
| `createAssetFolder` | `POST /v1/assets/folders` |
| `getAssetFolder` | `GET /v1/assets/folders/{id}` |
| `updateAssetFolder` | `PUT /v1/assets/folders/{id}` (204) |
| `deleteAssetFolder` | `DELETE /v1/assets/folders/{id}` (200) |

## ⚠️ The upload is multipart, not base64

The issue assumed the `SendEmailRequest.attach` base64 approach. Asset creation, however, is `multipart/form-data`; form field `file` plus optional `name` / `parent_folder_id` form values. The JSON mode that exists there only records metadata for an already-uploaded path; it never carries bytes. So base64-in-JSON would not work.

To support it, the transport gained a small, isolated multipart path:

- **`CIORequest.postForm(uri, form)` + `formOptions(...)`** (`lib/request.ts`): builds the request with a `FormData` body and **deliberately omits the JSON `Content-Type`** so `fetch` sets `multipart/form-data` with the correct boundary; no `Content-Length` is computed. Retries/redirects reuse the same `handler`/`execute` path unchanged (`RequestHandlerOptions.body` widened to `string | FormData | null`).
- **`createAsset`** builds `FormData` from a `Blob` (setting the blob's type when `contentType` is given, else letting the API derive it from the filename).

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the shared HTTP client (`RequestHandlerOptions`, `execute`) for FormData, but the multipart path is isolated; main risk is upload MIME handling and regressions on JSON requests.
> 
> **Overview**
> Adds **Assets** coverage to `APIClient`: list/upload/get/update/delete files and the same CRUD for asset folders (integer ids, page-based listing with optional folder filters).
> 
> **`createAsset`** posts `multipart/form-data` via a new **`postForm` / `formOptions`** path on the shared request layer. Request bodies can be `FormData`; JSON `Content-Type` and `Content-Length` are omitted so `fetch` sets the multipart boundary. The SDK derives MIME types from filename (or explicit `contentType` / Blob type) so uploads are not sent as `application/octet-stream`.
> 
> Public types (`AssetListOptions`, `CreateAssetInput`, etc.), **`docs/app.md`** reference, unit tests, request-layer tests, and live integration round-trips are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094101063fbd694db6c1a8bebfa44fcb24b8d4cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->