### PR TITLE
chore: release 5.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [5.2.0]
+
+This release completes the App API surface: `APIClient` now covers the full Customer.io [Journeys App API](https://docs.customer.io/api/app/). Every endpoint was verified against the live API behavior, with unit and live integration coverage.
+
+#### Added
+
+- **Transactional message management** on `APIClient`: `listTransactionalMessages`, `getTransactionalMessage`, `getTransactionalMessageContents`, `getTransactionalMessageMetrics`, `getTransactionalMessageMetricsLinks`, `getTransactionalMessageDeliveries`, and `updateTransactionalMessageContent`. ([#231](https://github.com/customerio/customerio-node/pull/231))
+- **`sendWhatsApp`** transactional method (with a `SendWhatsAppRequest` builder). ([#238](https://github.com/customerio/customerio-node/pull/238))
+- **Campaign methods**: list/get campaigns and actions, action & campaign content and localizations, metrics (campaign/action, link metrics, journey metrics), messages, and broadcast trigger status/errors. ([#232](https://github.com/customerio/customerio-node/pull/232))
+- **Broadcast methods**: list/get broadcasts and actions, action content, metrics, link metrics, messages, and triggers. ([#233](https://github.com/customerio/customerio-node/pull/233))
+- **Newsletter methods**: core CRUD, contents, metrics, messages, send/schedule, and localization + test-group management. ([#235](https://github.com/customerio/customerio-node/pull/235), [#236](https://github.com/customerio/customerio-node/pull/236))
+- **Design Studio methods**: folders and emails (list/create/get/update/delete), email translations (languages), and components. ([#239](https://github.com/customerio/customerio-node/pull/239), [#240](https://github.com/customerio/customerio-node/pull/240))
+- **Assets methods**: file upload (`createAsset`, `multipart/form-data`) and file/folder CRUD. ([#241](https://github.com/customerio/customerio-node/pull/241))
+- **Collections methods**: CRUD plus content read/replace. ([#242](https://github.com/customerio/customerio-node/pull/242))
+- **Deliverability methods**: ESP email-suppression management (`searchSuppression`, `getSuppressions`, `getDomainSuppressions`, `createSuppression`, `deleteSuppression`) and reporting-webhook CRUD. ([#243](https://github.com/customerio/customerio-node/pull/243))
+- **Content & sender utilities**: snippet CRUD, sender-identity reads (`getSenderIdentities`, `getSenderIdentity`, `getSenderIdentityUsedBy`), and the workspace message log (`getMessages`, `getMessage`, `getArchivedMessage`). ([#244](https://github.com/customerio/customerio-node/pull/244))
+- **Imports, data index & workspace info**: `createImport`, `getImport`, `batchUpdateAttributes`, `batchUpdateEvents`, `listWorkspaces`, and `getIpAddresses`. ([#245](https://github.com/customerio/customerio-node/pull/245))
+- **`ObjectFilter`** type for `findObjects`, plus top-level `not` support on audience/object filters. ([#234](https://github.com/customerio/customerio-node/pull/234))
+
+#### Fixed
+
+- **App API metric and message query parameters** now match the API: journey metrics send `resolution`; action metrics forward `type`/`unique` correctly; unsupported `type`/`state` params were removed; and campaign-metric `version` is optional. ([#237](https://github.com/customerio/customerio-node/pull/237))
+
 ## [5.1.0]
 
 #### Added

--- a/lib/version.ts
+++ b/lib/version.ts
@@ -1,1 +1,1 @@
-export const version = '5.1.0';
+export const version = '5.2.0';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "customerio-node",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "customerio-node",
-      "version": "5.1.0",
+      "version": "5.2.0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^22.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "customerio-node",
   "description": "A node client for the Customer.io event API. http://customer.io",
-  "version": "5.1.0",
+  "version": "5.2.0",
   "author": "Customer.io (https://customer.io)",
   "contributors": [
     "Alvin Crespo (https://github.com/alvincrespo)",


### PR DESCRIPTION
## Release 5.2.0

Bumps the version to **5.2.0** and adds the changelog entry. This release **completes the App API surface** — `APIClient` now covers the full Customer.io [Journeys App API](https://docs.customer.io/api/app/).

### Included since 5.1.0

**Added**
- Transactional message management ([#231](https://github.com/customerio/customerio-node/pull/231)) and `sendWhatsApp` ([#238](https://github.com/customerio/customerio-node/pull/238))
- Campaigns ([#232](https://github.com/customerio/customerio-node/pull/232)) and broadcasts ([#233](https://github.com/customerio/customerio-node/pull/233))
- Newsletters — core + localization/test groups ([#235](https://github.com/customerio/customerio-node/pull/235), [#236](https://github.com/customerio/customerio-node/pull/236))
- Design Studio — folders, emails, languages, components ([#239](https://github.com/customerio/customerio-node/pull/239), [#240](https://github.com/customerio/customerio-node/pull/240))
- Assets incl. multipart upload ([#241](https://github.com/customerio/customerio-node/pull/241))
- Collections ([#242](https://github.com/customerio/customerio-node/pull/242))
- Deliverability — ESP suppressions & reporting webhooks ([#243](https://github.com/customerio/customerio-node/pull/243))
- Snippets, sender identities, message log ([#244](https://github.com/customerio/customerio-node/pull/244))
- Imports, data index, workspaces, IP info ([#245](https://github.com/customerio/customerio-node/pull/245))
- `ObjectFilter` type + top-level `not` filter ([#234](https://github.com/customerio/customerio-node/pull/234))

**Fixed**
- App API metric/message query-parameter alignment ([#237](https://github.com/customerio/customerio-node/pull/237))

Assisted by AI 🤖 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only—no library source changes in this diff beyond the version constant.
> 
> **Overview**
> Prepares **5.2.0** for publish by bumping the package version in `package.json`, `package-lock.json`, and `lib/version.ts` from **5.1.0** to **5.2.0**.
> 
> Adds a **CHANGELOG** section for 5.2.0 that documents work already landed on main: full Journeys App API coverage on `APIClient` (transactional messages, WhatsApp, campaigns, broadcasts, newsletters, Design Studio, assets, collections, deliverability, snippets/senders/message log, imports/workspaces), plus `ObjectFilter` / filter `not` support and fixes for App API metric/message query parameters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f587fab3f0c20f7f25dcbdb219d6c6605cf0b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->